### PR TITLE
Change strapline

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -11,7 +11,7 @@
       <div class="container">
         <h1 class="jumbotron-heading display-4">Dash Bootstrap Components</h1>
         <p class="lead">
-          Easy to use layout and components for Plotly Dash
+          Responsive layouts and components for Plotly Dash
         </p>
         <p>
           <a


### PR DESCRIPTION
This changes the strapline to "Responsive layouts and components for Plotly Dash".

<img width="1440" alt="screenshot 2018-11-23 at 11 23 30" src="https://user-images.githubusercontent.com/1392879/48941219-8c792700-ef12-11e8-9247-9afebd645288.png">
