### PR TITLE
Change company name

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
   same "printed page" as the copyright notice for easier
   identification within third-party archives.
 
-Copyright 2018 ASI Data Science
+Copyright 2018-2019 Faculty Science Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ that can be composed with each other or with components in
 
 [dash-homepage]: https://dash.plot.ly/
 [bootstrap-homepage]: https://getbootstrap.com/
-[dbc-repo]: https://github.com/ASIDataScience/dash-bootstrap-components
+[dbc-repo]: https://github.com/facultyai/dash-bootstrap-components
 [reactstrap-homepage]: https://reactstrap.github.io/
 [docs-homepage]: https://dash-bootstrap-components.opensource.asidatascience.com
 [docs-components]: https://dash-bootstrap-components.opensource.asidatascience.com/l/components

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -128,7 +128,7 @@ class PopoverComponent extends Component {
 class Demo extends Component {
   render() {
     return (<React.Fragment>
-      <NavbarSimple sticky="top" brand="Dash Bootstrap Components" brand_href="https://github.com/ASIDataScience/dash-bootstrap-components">
+      <NavbarSimple sticky="top" brand="Dash Bootstrap Components" brand_href="https://github.com/facultyai/dash-bootstrap-components">
         <NavItem>
           <NavLink href="https://www.asidatascience.com">A link</NavLink>
         </NavItem>

--- a/docs/components_page/components/dropdown/simple.py
+++ b/docs/components_page/components/dropdown/simple.py
@@ -1,6 +1,6 @@
 import dash_bootstrap_components as dbc
 
-external_url = "https://github.com/asidatascience/dash-bootstrap-components"
+external_url = "https://github.com/facultyai/dash-bootstrap-components"
 
 dropdown = dbc.DropdownMenu(
     label="Menu",

--- a/docs/components_page/components/navbar/__init__.py
+++ b/docs/components_page/components/navbar/__init__.py
@@ -12,7 +12,7 @@ from ...helpers import (
 from ...metadata import get_component_metadata
 from .simple import navbar as navbar_simple
 
-GITHUB_EXAMPLES = "https://github.com/ASIDataScience/dash-bootstrap-components/blob/master/examples/advanced-component-usage/Navbars.py"  # noqa
+GITHUB_EXAMPLES = "https://github.com/facultyai/dash-bootstrap-components/blob/master/examples/advanced-component-usage/Navbars.py"  # noqa
 
 HERE = Path(__file__).parent
 

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -27,7 +27,7 @@ from .sidebar import Sidebar, SidebarEntry
 HERE = Path(__file__).parent
 COMPONENTS = HERE / "components"
 
-GITHUB_LINK = "https://github.com/ASIDataScience/dash-bootstrap-components"
+GITHUB_LINK = "https://github.com/facultyai/dash-bootstrap-components"
 
 NAVBAR = dbc.NavbarSimple(
     brand="Dash Bootstrap Components",

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -17,7 +17,7 @@
           <a
             role="button"
             class="btn btn-outline-primary"
-            href="https://github.com/asidatascience/dash-bootstrap-components">
+            href="https://github.com/facultyai/dash-bootstrap-components">
             GitHub
           </a>
           <a

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -186,13 +186,13 @@ if __name__ == "__main__":
           <p>
             If you find a bug, or if something is unclear, we
             encourage you to raise an issue on <a
-            href="https://github.com/ASIDataScience/dash-bootstrap-components/issues">GitHub</a>.
+            href="https://github.com/facultyai/dash-bootstrap-components/issues">GitHub</a>.
           </p>
           <p>
             We welcome contributions to
             <em>dash-bootstrap-components</em>. To contribute, fork
             the repository and open a <a
-            href="https://github.com/ASIDataScience/dash-bootstrap-components/pulls">pull
+            href="https://github.com/facultyai/dash-bootstrap-components/pulls">pull
             request</a>.
           </p>
         </div>

--- a/examples/components.py
+++ b/examples/components.py
@@ -5,7 +5,7 @@ import dash_html_components as html
 from dash.dependencies import Input, Output, State
 
 DBC_DOCS = "https://dash-bootstrap-components.opensource.asidatascience.com/"
-DBC_GITHUB = "https://github.com/ASIDataScience/dash-bootstrap-components"
+DBC_GITHUB = "https://github.com/facultyai/dash-bootstrap-components"
 
 app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
 

--- a/landing-page.md
+++ b/landing-page.md
@@ -31,7 +31,7 @@ repository and open a [pull request][dbc-pulls].
 
 [dash-homepage]: https://dash.plot.ly/
 [bootstrap-homepage]: https://getbootstrap.com/
-[dbc-repo]: https://github.com/ASIDataScience/dash-bootstrap-components
+[dbc-repo]: https://github.com/facultyai/dash-bootstrap-components
 [reactstrap-homepage]: https://reactstrap.github.io/
 [docs-homepage]: https://dash-bootstrap-components.opensource.asidatascience.com
-[dbc-pulls]: https://github.com/ASIDataScience/dash-bootstrap-components/pulls
+[dbc-pulls]: https://github.com/facultyai/dash-bootstrap-components/pulls

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "LICENSE.txt",
     "README.md"
   ],
-  "author": "ASI Data Science",
+  "author": "Faculty",
   "license": "Apache-2.0",
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=_get_long_description(),
     long_description_content_type="text/markdown",
     license="Apache Software License",
-    author="ASI Data Science",
+    author="Faculty",
     author_email="opensource@asidatascience.com",
     url="https://github.com/facultyai/dash-bootstrap-components",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     license="Apache Software License",
     author="ASI Data Science",
     author_email="opensource@asidatascience.com",
-    url="https://github.com/ASIDataScience/dash-bootstrap-components",
+    url="https://github.com/facultyai/dash-bootstrap-components",
     packages=find_packages(),
     install_requires=["dash>=0.32.1", "dash-html-components"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Apache Software License",
     author="Faculty",
-    author_email="opensource@asidatascience.com",
+    author_email="opensource@faculty.ai",
     url="https://github.com/facultyai/dash-bootstrap-components",
     packages=find_packages(),
     install_requires=["dash>=0.32.1", "dash-html-components"],


### PR DESCRIPTION
ASI Data Science (formally "Advanced Skills Initiative Limited", UK company number 08873131) has been renamed "Faculty Science Limited" as of 4th February 2019.