### PR TITLE
Switch domain names to faculty.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ that can be composed with each other or with components in
 [bootstrap-homepage]: https://getbootstrap.com/
 [dbc-repo]: https://github.com/facultyai/dash-bootstrap-components
 [reactstrap-homepage]: https://reactstrap.github.io/
-[docs-homepage]: https://dash-bootstrap-components.opensource.asidatascience.com
-[docs-components]: https://dash-bootstrap-components.opensource.asidatascience.com/l/components
+[docs-homepage]: https://dash-bootstrap-components.opensource.faculty.ai
+[docs-components]: https://dash-bootstrap-components.opensource.faculty.ai/l/components

--- a/examples/components.py
+++ b/examples/components.py
@@ -4,7 +4,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output, State
 
-DBC_DOCS = "https://dash-bootstrap-components.opensource.asidatascience.com/"
+DBC_DOCS = "https://dash-bootstrap-components.opensource.faculty.ai/"
 DBC_GITHUB = "https://github.com/facultyai/dash-bootstrap-components"
 
 app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])

--- a/landing-page.md
+++ b/landing-page.md
@@ -33,5 +33,5 @@ repository and open a [pull request][dbc-pulls].
 [bootstrap-homepage]: https://getbootstrap.com/
 [dbc-repo]: https://github.com/facultyai/dash-bootstrap-components
 [reactstrap-homepage]: https://reactstrap.github.io/
-[docs-homepage]: https://dash-bootstrap-components.opensource.asidatascience.com
+[docs-homepage]: https://dash-bootstrap-components.opensource.faculty.ai
 [dbc-pulls]: https://github.com/facultyai/dash-bootstrap-components/pulls


### PR DESCRIPTION
The documentation is now live at https://dash-bootstrap-components.opensource.faculty.ai/. This PR switches links to the new URL structure. 

At the moment, both `dash-bootstrap-components.opensource.{asidatascience.com,faculty.ai}` point to the Heroku app. When this is merged, I'll set up redirection from `...asidatascience.com` to `faculty.ai` so the former gets progressively purged from people's browsers.