### PR TITLE
Checkbox radio components documentation

### DIFF
--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -10,7 +10,6 @@ from ...helpers import (
     load_source_with_environment,
 )
 from ...metadata import get_component_metadata
-from .radio_check import inputs as input_radio_check
 from .size import inputs as input_size
 from .text_label import text_input as input_text_label
 from .textarea import textareas as input_textarea
@@ -109,7 +108,7 @@ def get_content(app):
                 "padding."
             )
         ),
-        ExampleContainer(input_radio_check),
+        ExampleContainer(load_source_with_environment(input_radio_check_source, "inputs", {"app": app})),
         HighlightedSource(input_radio_check_source),
         ApiDoc(
             get_component_metadata("src/components/input/Input.js"),

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -25,6 +25,7 @@ input_validation_source = (HERE / "validation.py").read_text()
 input_radio_check_source = (HERE / "radio_check.py").read_text()
 input_textarea_source = (HERE / "textarea.py").read_text()
 input_radio_check_inline_source = (HERE / "radio_check_inline.py").read_text()
+input_radio_check_standalone_source = (HERE / "radio_check_standalone.py").read_text()
 
 
 def get_content(app):
@@ -124,6 +125,15 @@ def get_content(app):
         ),
         ExampleContainer(inline_inputs),
         HighlightedSource(input_radio_check_inline_source),
+        html.P(
+            dcc.Markdown("standalone")
+        ),
+        ExampleContainer(
+            load_source_with_environment(
+                input_radio_check_standalone_source, "standalone_radio_check", {"app": app}
+                )
+            ),
+        HighlightedSource(input_radio_check_standalone_source),
         ApiDoc(
             get_component_metadata("src/components/input/Input.js"),
             component_name="Input",

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -162,4 +162,12 @@ def get_content(app):
             get_component_metadata("src/components/input/Checklist.js"),
             component_name="Checklist",
         ),
+        ApiDoc(
+            get_component_metadata("src/components/input/Checkbox.js"),
+            component_name="Checkbox",
+        ),
+        ApiDoc(
+            get_component_metadata("src/components/input/RadioButton.js"),
+            component_name="RadioButton",
+        ),
     ]

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -126,7 +126,15 @@ def get_content(app):
         ExampleContainer(inline_inputs),
         HighlightedSource(input_radio_check_inline_source),
         html.P(
-            dcc.Markdown("standalone")
+            dcc.Markdown(
+                "If you need more granular control over checkboxes "
+                "and radio buttons, you can also create standalone "
+                "components. Bind callbacks to the `checked` keyword "
+                "to react to changes in the input state. To attach "
+                "a label, create a FormGroup with `check=True` and "
+                "use the label's `html_for` keyword to bind it to "
+                "the checkbox."
+            )
         ),
         ExampleContainer(
             load_source_with_environment(

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -14,6 +14,7 @@ from .size import inputs as input_size
 from .text_label import text_input as input_text_label
 from .textarea import textareas as input_textarea
 from .validation import inputs as input_validation
+from .radio_check_inline import inline_inputs
 
 HERE = Path(__file__).parent
 
@@ -23,6 +24,7 @@ input_size_source = (HERE / "size.py").read_text()
 input_validation_source = (HERE / "validation.py").read_text()
 input_radio_check_source = (HERE / "radio_check.py").read_text()
 input_textarea_source = (HERE / "textarea.py").read_text()
+input_radio_check_inline_source = (HERE / "radio_check_inline.py").read_text()
 
 
 def get_content(app):
@@ -108,8 +110,20 @@ def get_content(app):
                 "padding."
             )
         ),
-        ExampleContainer(load_source_with_environment(input_radio_check_source, "inputs", {"app": app})),
+        ExampleContainer(
+            load_source_with_environment(
+                input_radio_check_source, "inputs", {"app": app}
+            )
+        ),
         HighlightedSource(input_radio_check_source),
+        html.P(
+            dcc.Markdown(
+                "Use the `inline` keyword to make the radioitems or "
+                "checklists fit next to each other on a line."
+            )
+        ),
+        ExampleContainer(inline_inputs),
+        HighlightedSource(input_radio_check_inline_source),
         ApiDoc(
             get_component_metadata("src/components/input/Input.js"),
             component_name="Input",

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -25,7 +25,9 @@ input_validation_source = (HERE / "validation.py").read_text()
 input_radio_check_source = (HERE / "radio_check.py").read_text()
 input_textarea_source = (HERE / "textarea.py").read_text()
 input_radio_check_inline_source = (HERE / "radio_check_inline.py").read_text()
-input_radio_check_standalone_source = (HERE / "radio_check_standalone.py").read_text()
+input_radio_check_standalone_source = (
+    HERE / "radio_check_standalone.py"
+).read_text()
 
 
 def get_content(app):
@@ -138,9 +140,11 @@ def get_content(app):
         ),
         ExampleContainer(
             load_source_with_environment(
-                input_radio_check_standalone_source, "standalone_radio_check", {"app": app}
-                )
-            ),
+                input_radio_check_standalone_source,
+                "standalone_radio_check",
+                {"app": app},
+            )
+        ),
         HighlightedSource(input_radio_check_standalone_source),
         ApiDoc(
             get_component_metadata("src/components/input/Input.js"),

--- a/docs/components_page/components/input/radio_check.py
+++ b/docs/components_page/components/input/radio_check.py
@@ -1,4 +1,6 @@
 import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output
 
 radioitems = dbc.FormGroup(
     [
@@ -9,6 +11,7 @@ radioitems = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             value=1,
+            id="radioitems-input"
         ),
     ]
 )
@@ -22,36 +25,18 @@ checklist = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             values=[],
+            id="checklist-input"
         ),
     ]
 )
 
-inline_radioitems = dbc.FormGroup(
-    [
-        dbc.Label("Choose one"),
-        dbc.RadioItems(
-            options=[
-                {"label": "Option 1", "value": 1},
-                {"label": "Option 2", "value": 2},
-            ],
-            value=1,
-            inline=True,
-        ),
-    ]
-)
+inputs = html.Div([dbc.Form([radioitems, checklist]), html.P(id="radioitems-checklist-output")])
 
-inline_checklist = dbc.FormGroup(
-    [
-        dbc.Label("Choose a bunch"),
-        dbc.Checklist(
-            options=[
-                {"label": "Option 1", "value": 1},
-                {"label": "Option 2", "value": 2},
-            ],
-            values=[],
-            inline=True,
-        ),
-    ]
+@app.callback(
+    Output("radioitems-checklist-output", "children"),
+    [Input("radioitems-input", "value"), Input("checklist-input", "values")]
 )
-
-inputs = dbc.Form([radioitems, checklist, inline_radioitems, inline_checklist])
+def on_form_change(radio_items_value, checklist_values):
+    output_string = "Radio button {} and {} checklist items are selected.".format(
+        radio_items_value, len(checklist_values))
+    return output_string

--- a/docs/components_page/components/input/radio_check.py
+++ b/docs/components_page/components/input/radio_check.py
@@ -11,7 +11,7 @@ radioitems = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             value=1,
-            id="radioitems-input"
+            id="radioitems-input",
         ),
     ]
 )
@@ -25,18 +25,25 @@ checklist = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             values=[],
-            id="checklist-input"
+            id="checklist-input",
         ),
     ]
 )
 
-inputs = html.Div([dbc.Form([radioitems, checklist]), html.P(id="radioitems-checklist-output")])
+inputs = html.Div(
+    [
+        dbc.Form([radioitems, checklist]),
+        html.P(id="radioitems-checklist-output"),
+    ]
+)
+
 
 @app.callback(
     Output("radioitems-checklist-output", "children"),
-    [Input("radioitems-input", "value"), Input("checklist-input", "values")]
+    [Input("radioitems-input", "value"), Input("checklist-input", "values")],
 )
 def on_form_change(radio_items_value, checklist_values):
     output_string = "Radio button {} and {} checklist items are selected.".format(
-        radio_items_value, len(checklist_values))
+        radio_items_value, len(checklist_values)
+    )
     return output_string

--- a/docs/components_page/components/input/radio_check.py
+++ b/docs/components_page/components/input/radio_check.py
@@ -43,7 +43,6 @@ inputs = html.Div(
     [Input("radioitems-input", "value"), Input("checklist-input", "values")],
 )
 def on_form_change(radio_items_value, checklist_values):
-    output_string = "Radio button {} and {} checklist items are selected.".format(
-        radio_items_value, len(checklist_values)
-    )
+    template = "Radio button {} and {} checklist items are selected."
+    output_string = template.format(radio_items_value, len(checklist_values))
     return output_string

--- a/docs/components_page/components/input/radio_check_inline.py
+++ b/docs/components_page/components/input/radio_check_inline.py
@@ -1,0 +1,31 @@
+import dash_bootstrap_components as dbc
+
+inline_radioitems = dbc.FormGroup(
+    [
+        dbc.Label("Choose one"),
+        dbc.RadioItems(
+            options=[
+                {"label": "Option 1", "value": 1},
+                {"label": "Option 2", "value": 2},
+            ],
+            value=1,
+            inline=True,
+        ),
+    ]
+)
+
+inline_checklist = dbc.FormGroup(
+    [
+        dbc.Label("Choose a bunch"),
+        dbc.Checklist(
+            options=[
+                {"label": "Option 1", "value": 1},
+                {"label": "Option 2", "value": 2},
+            ],
+            values=[],
+            inline=True,
+        ),
+    ]
+)
+
+inline_inputs = dbc.Form([inline_radioitems, inline_checklist])

--- a/docs/components_page/components/input/radio_check_standalone.py
+++ b/docs/components_page/components/input/radio_check_standalone.py
@@ -1,0 +1,45 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+standalone_radio_check = html.Div(
+    [
+        dbc.FormGroup(
+            [
+                dbc.Checkbox(id="standalone-checkbox", className="form-check-input"),
+                dbc.Label(
+                    "This is a checkbox",
+                    html_for="standalone-checkbox",
+                    className="form-check-label"
+                )
+            ],
+            check=True
+        ),
+        dbc.FormGroup(
+            [
+                dbc.RadioButton(id="standalone-radio", className="form-check-input"),
+                dbc.Label(
+                    "This is a radio button",
+                    html_for="standalone-radio",
+                    className="form-check-label"
+                )
+            ],
+            check=True
+        ),
+        html.Br(),
+        html.P(id="standalone-radio-check-output")
+    ]
+)
+
+@app.callback(
+    Output("standalone-radio-check-output", "children"),
+    [Input("standalone-checkbox", "checked"), Input("standalone-radio", "checked")]
+)
+def on_form_change(checkbox_checked, radio_checked):
+    if checkbox_checked and radio_checked:
+        return "Both checked."
+    elif checkbox_checked or radio_checked:
+        return "One checked."
+    else:
+        return "None checked."
+        

--- a/docs/components_page/components/input/radio_check_standalone.py
+++ b/docs/components_page/components/input/radio_check_standalone.py
@@ -6,34 +6,42 @@ standalone_radio_check = html.Div(
     [
         dbc.FormGroup(
             [
-                dbc.Checkbox(id="standalone-checkbox", className="form-check-input"),
+                dbc.Checkbox(
+                    id="standalone-checkbox", className="form-check-input"
+                ),
                 dbc.Label(
                     "This is a checkbox",
                     html_for="standalone-checkbox",
-                    className="form-check-label"
-                )
+                    className="form-check-label",
+                ),
             ],
-            check=True
+            check=True,
         ),
         dbc.FormGroup(
             [
-                dbc.RadioButton(id="standalone-radio", className="form-check-input"),
+                dbc.RadioButton(
+                    id="standalone-radio", className="form-check-input"
+                ),
                 dbc.Label(
                     "This is a radio button",
                     html_for="standalone-radio",
-                    className="form-check-label"
-                )
+                    className="form-check-label",
+                ),
             ],
-            check=True
+            check=True,
         ),
         html.Br(),
-        html.P(id="standalone-radio-check-output")
+        html.P(id="standalone-radio-check-output"),
     ]
 )
 
+
 @app.callback(
     Output("standalone-radio-check-output", "children"),
-    [Input("standalone-checkbox", "checked"), Input("standalone-radio", "checked")]
+    [
+        Input("standalone-checkbox", "checked"),
+        Input("standalone-radio", "checked"),
+    ],
 )
 def on_form_change(checkbox_checked, radio_checked):
     if checkbox_checked and radio_checked:
@@ -42,4 +50,3 @@ def on_form_change(checkbox_checked, radio_checked):
         return "One checked."
     else:
         return "None checked."
-        

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ exclude =
     docs/components_page/components/fade/fade.py,
     docs/components_page/components/form/feedback.py,
     docs/components_page/components/input/simple.py,
+    docs/components_page/components/input/radio_check_standalone.py,
+    docs/components_page/components/input/radio_check.py,
     docs/components_page/components/input_group/button.py,
     docs/components_page/components/input_group/dropdown.py,
     docs/components_page/components/list_group/links.py,


### PR DESCRIPTION
This PR adds an example application for the stand-alone checkbox and radio component.

It also splits the checklist and radioitems examples into two to give a more complete usage example.

I've made this PR target PR #134 for now. If PR 134 gets merged first, we can just re-target this to master.

The example for standalone checkboxes and radio buttons looks like:

<img width="877" alt="screenshot 2019-02-17 at 09 04 38" src="https://user-images.githubusercontent.com/1392879/52910687-1545fb80-3293-11e9-9c84-19e883512951.png">

The updated example for radioitems and checklists looks like:

<img width="845" alt="screenshot 2019-02-17 at 09 05 09" src="https://user-images.githubusercontent.com/1392879/52910700-445c6d00-3293-11e9-951b-5724920c3030.png">

The inline example looks like:

<img width="859" alt="screenshot 2019-02-17 at 09 06 21" src="https://user-images.githubusercontent.com/1392879/52910705-52aa8900-3293-11e9-907d-0b5642a48290.png">

