### PR TITLE
Add option to right align the dropdown menu

### DIFF
--- a/docs/components_page/components/dropdown/__init__.py
+++ b/docs/components_page/components/dropdown/__init__.py
@@ -5,10 +5,10 @@ import dash_html_components as html
 from ...api_doc import ApiDoc
 from ...helpers import ExampleContainer, HighlightedSource
 from ...metadata import get_component_metadata
+from .alignment import dropdown as dropdown_alignment
+from .direction import dropdown as dropdown_direction
 from .simple import dropdown as dropdown_simple
 from .size import dropdown as dropdown_size
-from .direction import dropdown as dropdown_direction
-from .alignment import dropdown as dropdown_alignment
 
 HERE = Path(__file__).parent
 

--- a/docs/components_page/components/dropdown/__init__.py
+++ b/docs/components_page/components/dropdown/__init__.py
@@ -5,15 +5,17 @@ import dash_html_components as html
 from ...api_doc import ApiDoc
 from ...helpers import ExampleContainer, HighlightedSource
 from ...metadata import get_component_metadata
-from .direction import dropdown as dropdown_direction
 from .simple import dropdown as dropdown_simple
 from .size import dropdown as dropdown_size
+from .direction import dropdown as dropdown_direction
+from .alignment import dropdown as dropdown_alignment
 
 HERE = Path(__file__).parent
 
 dropdown_simple_source = (HERE / "simple.py").read_text()
 dropdown_size_source = (HERE / "size.py").read_text()
 dropdown_direction_source = (HERE / "direction.py").read_text()
+dropdown_alignment_source = (HERE / "alignment.py").read_text()
 
 content = [
     html.H2("DropdownMenu"),
@@ -25,6 +27,9 @@ content = [
     html.H4("DropdownMenu direction"),
     ExampleContainer(dropdown_direction),
     HighlightedSource(dropdown_direction_source),
+    html.H4("DropdownMenu alignment"),
+    ExampleContainer(dropdown_alignment),
+    HighlightedSource(dropdown_alignment_source),
     ApiDoc(
         get_component_metadata("src/components/DropdownMenu.js"),
         component_name="DropdownMenu",

--- a/docs/components_page/components/dropdown/alignment.py
+++ b/docs/components_page/components/dropdown/alignment.py
@@ -13,13 +13,13 @@ dropdown = dbc.Row(
         dbc.Col(
             dbc.DropdownMenu(
                 label="Left-aligned menu (default)",
-                children=items, right=False
+                children=items,
+                right=False,
             )
         ),
         dbc.Col(
             dbc.DropdownMenu(
-                label="Right-aligned menu",
-                children=items, right=True
+                label="Right-aligned menu", children=items, right=True
             )
         ),
     ]

--- a/docs/components_page/components/dropdown/alignment.py
+++ b/docs/components_page/components/dropdown/alignment.py
@@ -1,0 +1,24 @@
+import dash_bootstrap_components as dbc
+
+items = [
+    dbc.DropdownMenuItem("Action"),
+    dbc.DropdownMenuItem("Another action"),
+    dbc.DropdownMenuItem("Something else here"),
+    dbc.DropdownMenuItem(divider=True),
+    dbc.DropdownMenuItem("Something else here after the divider"),
+]
+
+dropdown = dbc.Row(
+    [
+        dbc.Col(
+            dbc.DropdownMenu(
+                label="Left-aligned menu (default)", children=items, right=False
+            )
+        ),
+        dbc.Col(
+            dbc.DropdownMenu(
+                label="Right-aligned menu", children=items, right=True
+            )
+        ),
+    ]
+)

--- a/docs/components_page/components/dropdown/alignment.py
+++ b/docs/components_page/components/dropdown/alignment.py
@@ -12,12 +12,14 @@ dropdown = dbc.Row(
     [
         dbc.Col(
             dbc.DropdownMenu(
-                label="Left-aligned menu (default)", children=items, right=False
+                label="Left-aligned menu (default)",
+                children=items, right=False
             )
         ),
         dbc.Col(
             dbc.DropdownMenu(
-                label="Right-aligned menu", children=items, right=True
+                label="Right-aligned menu",
+                children=items, right=True
             )
         ),
     ]

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -31,6 +31,7 @@ class DropdownMenu extends React.Component {
       in_navbar,
       addon_type,
       bs_size,
+      right,
       ...otherProps
     } = this.props;
     return (
@@ -47,7 +48,7 @@ class DropdownMenu extends React.Component {
         <DropdownToggle nav={nav} caret={caret} disabled={disabled}>
           {label}
         </DropdownToggle>
-        <RSDropdownMenu>{this.props.children}</RSDropdownMenu>
+        <RSDropdownMenu right={right}>{this.props.children}</RSDropdownMenu>
       </Dropdown>
     );
   }
@@ -98,6 +99,11 @@ DropdownMenu.propTypes = {
    * the dropdown upwards is currently unsupported. Default: 'down'.
    */
   direction: PropTypes.oneOf(['down', 'left', 'right']),
+
+  /**
+   * Align the dropdown menu along the right side of its parent. Default: False.
+   */
+  right: PropTypes.bool,
 
   /**
    * Set this to True if the dropdown is inside a navbar. Default: False.


### PR DESCRIPTION
Change to add option to align the dropdown menu along the right side of its parent. Default: False.

![image](https://user-images.githubusercontent.com/37494306/53852968-cafe9300-3f91-11e9-8e07-e874526d2936.png)


![image](https://user-images.githubusercontent.com/37494306/53853004-e7023480-3f91-11e9-80f6-12473d821bcd.png)
