### PR TITLE
Use bootstrap 4.3.1

### DIFF
--- a/dash_bootstrap_components/themes.py
+++ b/dash_bootstrap_components/themes.py
@@ -1,10 +1,10 @@
 BOOTSTRAP = (
-    "https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
+    "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 )
 
-GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap-grid.min.css"  # noqa
+GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap-grid.min.css"  # noqa
 
-_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.2.1/"
+_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.3.1/"
 
 CERULEAN = _BOOTSWATCH_BASE + "cerulean/bootstrap.min.css"
 COSMO = _BOOTSWATCH_BASE + "cosmo/bootstrap.min.css"

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 
 <body>

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.13.1/build/styles/monokai-sublime.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='docs.css') }}" />
     <title>Dash Bootstrap Components</title>


### PR DESCRIPTION
Prior to this commit, we used Bootstrap 4.2.1 for the documentation, the demo and in dbc.themes. Bootstrap 4.3.0 and 4.3.1 were both released in early February.

I've tested this (visually) for regressions on the docs and demo, including some of the Bootstwatch themes.