### PR TITLE
Fix unsorted imports in __init__.py files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - "if [[ \"$GROUP\" == js ]] ; then pip install dash ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm -v ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm install ; fi"
-  - "if [[ \"$GROUP\" == python-linting ]] ; then pip install black flake8 isort ; fi"
+  - "if [[ \"$GROUP\" == python-linting ]] ; then pip install black flake8 isort>=4.3.5 ; fi"
 script:
   - "if [[ \"$GROUP\" == js ]] ; then npm run lint ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm run test ; fi"

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -10,11 +10,11 @@ from ...helpers import (
     load_source_with_environment,
 )
 from ...metadata import get_component_metadata
+from .radio_check_inline import inline_inputs
 from .size import inputs as input_size
 from .text_label import text_input as input_text_label
 from .textarea import textareas as input_textarea
 from .validation import inputs as input_validation
-from .radio_check_inline import inline_inputs
 
 HERE = Path(__file__).parent
 


### PR DESCRIPTION
Since isort 4.3.5 ([release notes](https://github.com/timothycrosley/isort/releases/tag/4.3.5)), `__init__.py` files are also sorted. I'm not sure why isort did not consider these files before.

This means that any `__init__.py` file that was previously unsorted breaks our build pipeline.