### PR TITLE
Fix setting props on input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.3.5",
+  "version": "0.3.6-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6736,6 +6736,75 @@
       "requires": {
         "jest-mock": "^23.2.0",
         "jest-util": "^23.4.0"
+      }
+    },
+    "jest-extended": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.1.tgz",
+      "integrity": "sha512-4klauyMgaoqMG27yu2HMGoQLVJ5ntJuJRgUKA/HS0oiGNBuSOkXNB7dxDtL83qYaBDMLVaOjy23QPLXFASUbVg==",
+      "dev": true,
+      "requires": {
+        "expect": "^23.6.0",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+          "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme-adapter-react-16": "^1.5.0",
     "jest": "^23.6.0",
     "jest-environment-jsdom-global": "^1.1.0",
+    "jest-extended": "^0.11.1",
     "jsdom": "^12.0.0",
     "mkdirp": "^0.5.1",
     "move-cli": "^1.2.0",

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -240,8 +240,10 @@ Input.propTypes = {
   n_blur_timestamp: PropTypes.number,
 
   /**
-   * If true, changes to input will be sent back to the Dash server only on enter or when losing focus.
-   * If it's false, it will sent the value back on every change.
+   * If true, changes to input will be sent back to the Dash server
+   * only when the enter key is pressed or when the component loses
+   * focus.  If it's false, it will sent the value back on every
+   * change.
    */
   debounce: PropTypes.bool
 };

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -12,11 +12,9 @@ class Input extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    this.setState({value: nextProps.value})
     if (this.props.setProps) {
       this.props = nextProps;
-      if (this.props.debounce) {
-        this.setState({value: nextProps.value});
-      }
     }
   }
 

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -23,5 +23,12 @@ describe('Input', () => {
       const htmlInput = input.find('input')
       expect(htmlInput.prop('value')).toEqual('some-value')
     })
+
+    it('pass on changes in the value prop', () => {
+      const input = shallow(<Input />)
+      input.setProps({value: 'some-value'})
+      const htmlInput = input.find('input')
+      expect(htmlInput.prop('value')).toEqual('some-value')
+    })
   })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -65,4 +65,25 @@ describe('Input', () => {
       expect(setProps.mock.calls).toHaveLength(0)
     })
   })
+
+  describe('onBlur for input', () => {
+    it('dispatch setProps', () => {
+      const setProps = jest.fn()
+      const input = shallow(
+        <Input
+          n_blur={0}
+          n_blur_timestamp={-1}
+          setProps={setProps}
+        />
+      )
+      const htmlInput = input.find('input')
+      htmlInput.simulate('blur')
+      expect(setProps.mock.calls).toHaveLength(1)
+      const [call] = setProps.mock.calls
+      const [arg] = call
+      const { n_blur, n_blur_timestamp } = arg
+      expect(n_blur).toEqual(1)
+      expect(n_blur_timestamp).toBeValidDate()
+    })
+  })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import Input from '../Input';
+
+describe('Input', () => {
+  it('create an input', () => {
+    const input = shallow(<Input />)
+    const htmlInput = input.find('input')
+    expect(htmlInput).toHaveLength(1)
+  })
+})

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -10,4 +10,18 @@ describe('Input', () => {
     const htmlInput = input.find('input')
     expect(htmlInput).toHaveLength(1)
   })
+
+  describe('value', () => {
+    it('push no value by default', () => {
+      const input = shallow(<Input />)
+      const htmlInput = input.find('input')
+      expect(htmlInput.prop('value')).toBeUndefined()
+    })
+
+    it('pass a value onto the html input', () => {
+      const input = shallow(<Input value="some-value" />)
+      const htmlInput = input.find('input')
+      expect(htmlInput.prop('value')).toEqual('some-value')
+    })
+  })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -48,5 +48,15 @@ describe('Input', () => {
       htmlInput.simulate('change', {target: {value: 'some-value'}})
       expect(setProps.mock.calls).toEqual([[{value: 'some-value'}]])
     })
+
+    it('update the input and not setProps if debounce is true', () => {
+      const setProps = jest.fn()
+      const input = shallow(<Input debounce={true} setProps={setProps} />)
+      const htmlInputBeforeChange = input.find('input')
+      htmlInputBeforeChange.simulate('change', {target: {value: 'some-value'}})
+      const htmlInputAfterChange = input.find('input')
+      expect(htmlInputAfterChange.prop('value')).toEqual('some-value')
+      expect(setProps.mock.calls).toHaveLength(0)
+    })
   })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -108,4 +108,50 @@ describe('Input', () => {
       expect(value).toEqual('some-value')
     })
   })
+
+  describe('onKeyPress for input', () => {
+    const event = { key: 'Enter' }
+
+    it('dispatch setProps', () => {
+      const setProps = jest.fn()
+      const input = shallow(
+        <Input
+          n_submit={0}
+          n_submit_timestamp={-1}
+          setProps={setProps}
+        />
+      )
+      input.simulate('keyPress', event)
+      expect(setProps.mock.calls).toHaveLength(1)
+      const [[{n_submit, n_submit_timestamp}]] = setProps.mock.calls
+      expect(n_submit).toEqual(1)
+      expect(n_submit_timestamp).toBeValidDate()
+    })
+
+    it('dispatch the value if debounce is true', () => {
+      const setProps = jest.fn()
+      const input = shallow(
+        <Input
+          n_submit={0}
+          n_submit_timestamp={-1}
+          setProps={setProps}
+          debounce={true}
+          value="some-value"
+        />
+      )
+      input.simulate('keyPress', event)
+      expect(setProps.mock.calls).toHaveLength(1)
+      const [[{n_submit, n_submit_timestamp, value}]] = setProps.mock.calls
+      expect(n_submit).toEqual(1)
+      expect(n_submit_timestamp).toBeValidDate()
+      expect(value).toEqual("some-value")
+    })
+
+    it('do nothing if the key is not enter', () => {
+      const setProps = jest.fn()
+      const input = shallow(<Input setProps={setProps} />)
+      input.simulate('keyPress', {key: 'a'})
+      expect(setProps.mock.calls).toHaveLength(0)
+    })
+  })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -85,5 +85,27 @@ describe('Input', () => {
       expect(n_blur).toEqual(1)
       expect(n_blur_timestamp).toBeValidDate()
     })
+
+    it('dispatch the value if debounce is true', () => {
+      const setProps = jest.fn()
+      const input = shallow(
+        <Input
+          n_blur={0}
+          n_blur_timestamp={-1}
+          setProps={setProps}
+          debounce={true}
+          value="some-value"
+        />
+      )
+      const htmlInput = input.find('input')
+      htmlInput.simulate('blur')
+      expect(setProps.mock.calls).toHaveLength(1)
+      const [call] = setProps.mock.calls
+      const [arg] = call
+      const { n_blur, n_blur_timestamp, value } = arg
+      expect(n_blur).toEqual(1)
+      expect(n_blur_timestamp).toBeValidDate()
+      expect(value).toEqual('some-value')
+    })
   })
 })

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -33,10 +33,16 @@ describe('Input', () => {
   })
 
   describe('onChange for input', () => {
+    const mockEvent = {
+      target: {
+        value: 'some-value'
+      }
+    }
+
     it('update the input if setProps is undefined', () => {
       const input = shallow(<Input />)
       const htmlInputBeforeChange = input.find('input')
-      htmlInputBeforeChange.simulate('change', {target: {value: 'some-value'}})
+      htmlInputBeforeChange.simulate('change', mockEvent)
       const htmlInputAfterChange = input.find('input')
       expect(htmlInputAfterChange.prop('value')).toEqual('some-value')
     })
@@ -45,7 +51,7 @@ describe('Input', () => {
       const setProps = jest.fn()
       const input = shallow(<Input setProps={setProps} />)
       const htmlInput = input.find('input')
-      htmlInput.simulate('change', {target: {value: 'some-value'}})
+      htmlInput.simulate('change', mockEvent)
       expect(setProps.mock.calls).toEqual([[{value: 'some-value'}]])
     })
 
@@ -53,7 +59,7 @@ describe('Input', () => {
       const setProps = jest.fn()
       const input = shallow(<Input debounce={true} setProps={setProps} />)
       const htmlInputBeforeChange = input.find('input')
-      htmlInputBeforeChange.simulate('change', {target: {value: 'some-value'}})
+      htmlInputBeforeChange.simulate('change', mockEvent)
       const htmlInputAfterChange = input.find('input')
       expect(htmlInputAfterChange.prop('value')).toEqual('some-value')
       expect(setProps.mock.calls).toHaveLength(0)

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -31,4 +31,22 @@ describe('Input', () => {
       expect(htmlInput.prop('value')).toEqual('some-value')
     })
   })
+
+  describe('onChange for input', () => {
+    it('update the input if setProps is undefined', () => {
+      const input = shallow(<Input />)
+      const htmlInputBeforeChange = input.find('input')
+      htmlInputBeforeChange.simulate('change', {target: {value: 'some-value'}})
+      const htmlInputAfterChange = input.find('input')
+      expect(htmlInputAfterChange.prop('value')).toEqual('some-value')
+    })
+
+    it('call setProps if debounce is false', () => {
+      const setProps = jest.fn()
+      const input = shallow(<Input setProps={setProps} />)
+      const htmlInput = input.find('input')
+      htmlInput.simulate('change', {target: {value: 'some-value'}})
+      expect(setProps.mock.calls).toEqual([[{value: 'some-value'}]])
+    })
+  })
 })

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,6 @@
+// jest-extended
+import 'jest-extended';
+
 // enzyme
 import {configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';


### PR DESCRIPTION
Prior to this commit, changing the value prop on `Input` didn't result in the value of the underlying DOM input changing. In practice, this meant callbacks that changed the `value` attribute of the Input did nothing.

As a minimal reproducible example:

```py
import dash_bootstrap_components as dbc
import dash
from dash.dependencies import Input, Output

app = dash.Dash(__name__)

app.layout = dbc.Container(
    [
        dbc.Input(id='example-input'),
        dbc.Button(id='example-button')
    ]
)

@app.callback(
    Output('example-input', 'value'),
    [Input('example-button', 'n_clicks')]
)
def _cb(n_clicks):
    return str(n_clicks)


if __name__ == '__main__':
    app.run_server(port=8888)
```

The underlying problem is that `value` is only transferred from the props to the state on initial construction, not when the input receives new props. This fix changes the behaviour so that the state is always set.

This PR also:
- adds tests for the behaviour of the Input component when the props change or when events are fired (looking specifically at the interaction of `setProps` and `debounce`).
- improves the wording of the `debounce` prop (which I think is a poor name, but reasonable since it matches dcc's input).