### PR TITLE
Add support for disabling tabs

### DIFF
--- a/docs/components_page/components/tabs/__init__.py
+++ b/docs/components_page/components/tabs/__init__.py
@@ -34,7 +34,10 @@ def get_content(app):
                 "`Tab` components as children. Use the `label` argument to "
                 "specify the label in the tab. `Tabs` will automatically "
                 "switch between tabs for you by displaying and hiding the "
-                "content of each `Tab` below the tab pane."
+                "content of each `Tab` below the tab pane. You can also use "
+                "the `disabled` argument to disable individual tabs. This "
+                "will cause the label to be grayed out and make the tab "
+                "unresponsive to being clicked."
             )
         ),
         ExampleContainer(tabs_simple),

--- a/docs/components_page/components/tabs/simple.py
+++ b/docs/components_page/components/tabs/simple.py
@@ -25,5 +25,8 @@ tabs = dbc.Tabs(
     [
         dbc.Tab(tab1_content, label="Tab 1"),
         dbc.Tab(tab2_content, label="Tab 2"),
+        dbc.Tab(
+            "This tab's content is never seen", label="Tab 3", disabled=True
+        ),
     ]
 )

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -5,6 +5,10 @@ const Tab = props => {
   return <div>{props.children}</div>;
 };
 
+Tab.defaultProps = {
+  disabled: false
+}
+
 Tab.propTypes = {
   /**
    * The ID of this component, used to identify dash components
@@ -59,7 +63,12 @@ Tab.propTypes = {
    * will be set to "tab-i" where i is (zero indexed) position of tab in list
    * tabs pased to Tabs component.
    */
-  tab_id: PropTypes.string
+  tab_id: PropTypes.string,
+
+  /**
+   * Determines if tab is disabled or not - defaults to false
+   */
+  disabled: PropTypes.bool
 };
 
 export default Tab;

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -62,8 +62,11 @@ class Tabs extends React.Component {
               active: this.state.activeTab === tabId
             })}
             style={child.props.label_style}
+            disabled={child.props.disabled}
             onClick={() => {
-              this.toggle(tabId);
+              if (!child.props.disabled) {
+                this.toggle(tabId);
+              }
             }}
           >
             {child.props.label}


### PR DESCRIPTION
This PR adds a prop called `disabled` to `Tab` which allows you to disable tabs, making it unclickable and applying the disabled style.