### PR TITLE
Dismissable alerts

### DIFF
--- a/docs/components_page/components/alert/__init__.py
+++ b/docs/components_page/components/alert/__init__.py
@@ -1,19 +1,79 @@
 from pathlib import Path
 
+import dash_core_components as dcc
 import dash_html_components as html
 
 from ...api_doc import ApiDoc
-from ...helpers import ExampleContainer, HighlightedSource
+from ...helpers import (
+    ExampleContainer,
+    HighlightedSource,
+    load_source_with_environment,
+)
 from ...metadata import get_component_metadata
-from .alert import alerts
+from .content import alert as alert_content
+from .link import alerts as alerts_link
+from .simple import alerts as alerts_simple
 
 HERE = Path(__file__).parent
 
-source = (HERE / "alert.py").read_text()
+alerts_simple_source = (HERE / "simple.py").read_text()
+alerts_link_source = (HERE / "link.py").read_text()
+alert_content_source = (HERE / "content.py").read_text()
+alerts_dismiss_source = (HERE / "dismiss.py").read_text()
 
-content = [
-    html.H2("Alert"),
-    ExampleContainer(alerts),
-    HighlightedSource(source),
-    ApiDoc(get_component_metadata("src/components/Alert.js")),
-]
+
+def get_content(app):
+    return [
+        html.H2("Alerts", className="display-4"),
+        html.P(
+            dcc.Markdown(
+                "Provide contextual feedback messages for user actions with "
+                "the `Alert` component."
+            ),
+            className="lead",
+        ),
+        html.H4("Basic usage"),
+        html.P(
+            dcc.Markdown(
+                "Set the color of `Alert` using the `color` argument and one "
+                "of the eight supported contextual color names."
+            )
+        ),
+        ExampleContainer(alerts_simple),
+        HighlightedSource(alerts_simple_source),
+        html.H4("Link color"),
+        html.P(
+            dcc.Markdown(
+                "The Bootstrap `alert-link` class can be used to color match "
+                "links inside alerts to the color of the alert."
+            )
+        ),
+        ExampleContainer(alerts_link),
+        HighlightedSource(alerts_link_source),
+        html.H4("Additional content"),
+        html.P(
+            dcc.Markdown(
+                "Alerts can contain additional HTML elements like headings, "
+                "paragraphs and dividers."
+            )
+        ),
+        ExampleContainer(alert_content),
+        HighlightedSource(alert_content_source),
+        html.H4("Dismissing"),
+        html.P(
+            dcc.Markdown(
+                "Set `dismissable=True` to add a dismiss button to the alert "
+                "which closes the alert on click. You can also use the "
+                "`is_open` property in callbacks to show or hide the alert. "
+                "By default the alert appears and disappears with a fade "
+                "animation. To disable this simply set `fade=False`."
+            )
+        ),
+        ExampleContainer(
+            load_source_with_environment(
+                alerts_dismiss_source, "alert", {"app": app}
+            )
+        ),
+        HighlightedSource(alerts_dismiss_source),
+        ApiDoc(get_component_metadata("src/components/Alert.js")),
+    ]

--- a/docs/components_page/components/alert/alert.py
+++ b/docs/components_page/components/alert/alert.py
@@ -1,9 +1,0 @@
-import dash_bootstrap_components as dbc
-import dash_html_components as html
-
-alerts = html.Div(
-    [
-        dbc.Alert("This is an alert", color="primary"),
-        dbc.Alert("Danger!", color="danger"),
-    ]
-)

--- a/docs/components_page/components/alert/content.py
+++ b/docs/components_page/components/alert/content.py
@@ -1,0 +1,18 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+alert = dbc.Alert(
+    [
+        html.H4("Well done!", className="alert-heading"),
+        html.P(
+            "This is a success alert with loads of extra text in it. So much "
+            "that you can see how spacing within an alert works with this "
+            "kind of content."
+        ),
+        html.Hr(),
+        html.P(
+            "Let's put some more text down here, but remove the bottom margin",
+            className="mb-0",
+        ),
+    ]
+)

--- a/docs/components_page/components/alert/dismiss.py
+++ b/docs/components_page/components/alert/dismiss.py
@@ -1,0 +1,48 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+
+alert = html.Div(
+    [
+        dbc.Button(
+            "Toggle alert with fade", id="alert-toggle-fade", className="mr-1"
+        ),
+        dbc.Button("Toggle alert without fade", id="alert-toggle-no-fade"),
+        html.Hr(),
+        dbc.Alert(
+            "Hello! I am an alert",
+            id="alert-fade",
+            dismissable=True,
+            is_open=True,
+        ),
+        dbc.Alert(
+            "Hello! I am an alert that doesn't fade in or out",
+            id="alert-no-fade",
+            dismissable=True,
+            fade=False,
+            is_open=True,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("alert-fade", "is_open"),
+    [Input("alert-toggle-fade", "n_clicks")],
+    [State("alert-fade", "is_open")],
+)
+def toggle_alert(n, is_open):
+    if n:
+        return not is_open
+    return is_open
+
+
+@app.callback(
+    Output("alert-no-fade", "is_open"),
+    [Input("alert-toggle-no-fade", "n_clicks")],
+    [State("alert-no-fade", "is_open")],
+)
+def toggle_alert_no_fade(n, is_open):
+    if n:
+        return not is_open
+    return is_open

--- a/docs/components_page/components/alert/link.py
+++ b/docs/components_page/components/alert/link.py
@@ -1,0 +1,21 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+alerts = html.Div(
+    [
+        dbc.Alert(
+            [
+                "This is a primary alert with an ",
+                html.A("example link", href="#", className="alert-link"),
+            ],
+            color="primary",
+        ),
+        dbc.Alert(
+            [
+                "This is a danger alert with an ",
+                html.A("example link", href="#", className="alert-link"),
+            ],
+            color="danger",
+        ),
+    ]
+)

--- a/docs/components_page/components/alert/simple.py
+++ b/docs/components_page/components/alert/simple.py
@@ -1,0 +1,15 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+alerts = html.Div(
+    [
+        dbc.Alert("This is a primary alert", color="primary"),
+        dbc.Alert("This is a secondary alert", color="secondary"),
+        dbc.Alert("This is a success alert! Well done!", color="success"),
+        dbc.Alert("This is a warning alert... be careful...", color="warning"),
+        dbc.Alert("This is a danger alert. Scary!", color="danger"),
+        dbc.Alert("This is an info alert. Good to know!", color="info"),
+        dbc.Alert("This is a light alert", color="light"),
+        dbc.Alert("This is a dark alert", color="dark"),
+    ]
+)

--- a/docs/components_page/page.py
+++ b/docs/components_page/page.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import dash_bootstrap_components as dbc
 
-from .components.alert import content as alert_content
+from .components.alert import get_content as get_alert_content
 from .components.badge import content as badge_content
 from .components.button import get_content as get_button_content
 from .components.card import content as card_content
@@ -76,7 +76,7 @@ class ComponentsPage:
     def __init__(self, app):
         self._app = app
         self._component_bodies = {
-            "alert": alert_content,
+            "alert": get_alert_content(self._app),
             "badge": badge_content,
             "button": get_button_content(self._app),
             "card": card_content,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 exclude =
     node_modules,
     dash_bootstrap_components/_components,
+    docs/components_page/components/alert/dismiss.py,
     docs/components_page/components/button/usage.py,
     docs/components_page/components/collapse/collapse.py,
     docs/components_page/components/fade/fade.py,

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -2,13 +2,47 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Alert as RSAlert} from 'reactstrap';
 
-const Alert = props => {
-  const {children, is_open, ...otherProps} = props;
-  return (
-    <RSAlert isOpen={is_open} {...otherProps}>
-      {children}
-    </RSAlert>
-  );
+class Alert extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.onDismiss = this.onDismiss.bind(this);
+
+    this.state = {
+      alertOpen: props.is_open
+    };
+  }
+
+  onDismiss() {
+    if (this.props.setProps) {
+      this.props.setProps({is_open: false});
+    } else {
+      this.setState({alertOpen: false});
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.is_open != this.state.alertOpen) {
+      this.setState({alertOpen: nextProps.is_open});
+    }
+  }
+
+  render() {
+    const {children, dismissable, is_open, ...otherProps} = this.props;
+    return (
+      <RSAlert
+        isOpen={this.state.alertOpen}
+        toggle={dismissable && this.onDismiss}
+        {...otherProps}
+      >
+        {children}
+      </RSAlert>
+    );
+  }
+}
+
+Alert.defaultProps = {
+  is_open: true
 };
 
 Alert.propTypes = {
@@ -56,7 +90,12 @@ Alert.propTypes = {
    * If True, a fade animation will be applied when `is_open` is toggled. If
    * False the Alert will simply appear and disappear.
    */
-  fade: PropTypes.bool
+  fade: PropTypes.bool,
+
+  /**
+   * If true, add a close button that allows Alert to be dismissed.
+   */
+  dismissable: PropTypes.bool
 };
 
 export default Alert;


### PR DESCRIPTION
This PR adds a `dismissable` prop to `Alert` which, when set to `True`, adds a dismiss button to the alert. It can be used alongside the existing `is_open` prop to display or dismiss alerts. See the following screenshot:

![image](https://user-images.githubusercontent.com/15220906/54741736-3e6dea80-4bb7-11e9-9a41-7577355892f3.png)

I have also taken the opportunity to improve the alert documentation, and add some more detailed examples.