### PR TITLE
Tab styling

### DIFF
--- a/docs/components_page/components/tabs/__init__.py
+++ b/docs/components_page/components/tabs/__init__.py
@@ -12,12 +12,14 @@ from ...helpers import (
 from ...metadata import get_component_metadata
 from .simple import tab1_content, tab2_content
 from .simple import tabs as tabs_simple
+from .style import tabs as tabs_style
 
 HERE = Path(__file__).parent
 
 tabs_simple_source = (HERE / "simple.py").read_text()
 tabs_active_source = (HERE / "active_tab.py").read_text()
 tabs_card_source = (HERE / "card.py").read_text()
+tabs_style_source = (HERE / "style.py").read_text()
 
 
 def get_content(app):
@@ -77,6 +79,27 @@ def get_content(app):
             )
         ),
         HighlightedSource(tabs_card_source),
+        html.H4("Styling tabs"),
+        html.P(
+            dcc.Markdown(
+                "You can modify the style of the tabs and labels using the "
+                "`tab_style` and `label_style` properties. Use `tab_style` to "
+                "modify the tab itself, for example to modify placement and "
+                "spacing. Use `label_style` to modify the label, for example "
+                "the font, text color, border-radius and so on."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "You can also apply CSS classes to the tab or label using the "
+                "`tabClassName` or `labelClassName` properties. In the below "
+                "example we apply the Bootstrap classes `ml-auto`, which sets "
+                "the left margin to `auto`, and `text-success`, which sets "
+                "the text color to the theme's 'success' color."
+            )
+        ),
+        ExampleContainer(tabs_style),
+        HighlightedSource(tabs_style_source),
         ApiDoc(
             get_component_metadata("src/components/tabs/Tabs.js"),
             component_name="Tabs",

--- a/docs/components_page/components/tabs/style.py
+++ b/docs/components_page/components/tabs/style.py
@@ -1,0 +1,20 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+tabs = html.Div(
+    [
+        dbc.Tabs(
+            [
+                dbc.Tab(label="Tab 1", tab_style={"margin-left": "auto"}),
+                dbc.Tab(label="Tab 2", label_style={"color": "#00AEF9"}),
+            ]
+        ),
+        html.Br(),
+        dbc.Tabs(
+            [
+                dbc.Tab(label="Tab 1", tabClassName="ml-auto"),
+                dbc.Tab(label="Tab 2", labelClassName="text-success"),
+            ]
+        ),
+    ]
+)

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -42,6 +42,18 @@ Tab.propTypes = {
   className: PropTypes.string,
 
   /**
+   * Often used with CSS to style elements with common properties. The classes
+   * specified with this prop will be applied to the NavItem in the tab.
+   */
+  tabClassName: PropTypes.string,
+
+  /**
+   * Often used with CSS to style elements with common properties. The classes
+   * specified with this prop will be applied to the NavLink in the tab.
+   */
+  labelClassName: PropTypes.string,
+
+  /**
    * A unique identifier for the component, used to improve
    * performance by React.js while rendering components
    * See https://reactjs.org/docs/lists-and-keys.html for more info

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -56,9 +56,13 @@ class Tabs extends React.Component {
       child = child.props.children;
       const tabId = child.props.key || child.props.tab_id || 'tab-' + idx;
       return (
-        <NavItem key={tabId} style={child.props.tab_style}>
+        <NavItem
+          key={tabId}
+          style={child.props.tab_style}
+          className={child.props.tabClassName}
+        >
           <NavLink
-            className={classnames({
+            className={classnames(child.props.labelClassName, {
               active: this.state.activeTab === tabId
             })}
             style={child.props.label_style}
@@ -75,7 +79,16 @@ class Tabs extends React.Component {
     // create tab content by extracting children from children
     const tabs = children.map((child, idx) => {
       child = child.props.children;
-      const {children, tab_id, label, tab_style, label_style, ...otherProps} = child.props;
+      const {
+        children,
+        tab_id,
+        label,
+        tab_style,
+        label_style,
+        tabClassName,
+        labelClassName,
+        ...otherProps
+      } = child.props;
       const tabId = tab_id || 'tab-' + idx;
       return (
         <TabPane tabId={tabId} key={tabId} {...otherProps}>


### PR DESCRIPTION
This PR documents the new `tab_style` and `label_style` props, addressing #155.

While preparing the documentation, it occurred to me that it would be useful to also be able to set the className of the tab and label, not just the style, so I've included that here and added it to the documentation as well.