### PR TITLE
Fix Tabs in Dash 0.40.0

### DIFF
--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -44,6 +44,7 @@ import {
   Tab,
   Tabs,
   Table,
+  Textarea,
   Tooltip,
 } from '../src';
 
@@ -402,7 +403,7 @@ class Demo extends Component {
         </FormGroup>
         <FormGroup>
           <Label for="exampleText">Text Area</Label>
-          <Input type="textarea" name="text" id="exampleText"/>
+          <Textarea id="exampleText"/>
         </FormGroup>
         <Button>Submit</Button>
       </Form>
@@ -474,9 +475,8 @@ class Demo extends Component {
 
       <h2>Tabs</h2>
       <Tabs>
-        {/* wrap in div to replicate dash renderer behavior */}
-        <div><Tab tab_id="1" label="Tab 1">Tab 1</Tab></div>
-        <div><Tab tab_id="2" label="Tab 2">Tab 2</Tab></div>
+        <Tab tab_id="1" label="Tab 1"><p>This is tab 1</p></Tab>
+        <Tab tab_id="2" label="Tab 2">Tab 2</Tab>
       </Tabs>
 
       <br/>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-dash==0.31.1
+dash>=0.40.0
 dash_bootstrap_components==0.3.5
 dash_core_components
 dash_html_components

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email="opensource@faculty.ai",
     url="https://github.com/facultyai/dash-bootstrap-components",
     packages=find_packages(),
-    install_requires=["dash>=0.32.1", "dash-html-components"],
+    install_requires=["dash>=0.40.0"],
     include_package_data=True,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR addresses #164.

Background
When using `Tabs` and `Tab`, each `Tab` is not really a child of `Tabs` in the usual sense. Instead `Tabs` iterates over the `Tab` components passed to it and extracts things like the label and content. With the release of Dash 0.40.0 the internal structure of the Dash components being iterated over changed, and the `children` prop was replaced with `_dashprivate_layout`. This PR changes the relevant references to children and updates the version requirement for Dash in the setup file (this will no longer work with older versions of Dash).