### PR TITLE
Expose style prop in ButtonGroup

### DIFF
--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -21,6 +21,11 @@ ButtonGroup.propTypes = {
   children: PropTypes.node,
 
   /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
    * Often used with CSS to style elements with common properties.
    */
   className: PropTypes.string,


### PR DESCRIPTION
This PR addresses #163 by exposing the `style` prop of `ButtonGroup`.