### PR TITLE
Improve documentation of badges

### DIFF
--- a/docs/components_page/components/badge/__init__.py
+++ b/docs/components_page/components/badge/__init__.py
@@ -1,19 +1,78 @@
 from pathlib import Path
 
+import dash_core_components as dcc
 import dash_html_components as html
 
 from ...api_doc import ApiDoc
 from ...helpers import ExampleContainer, HighlightedSource
 from ...metadata import get_component_metadata
-from .badge import badges
+from .color import badges as badges_color
+from .links import badges as badges_links
+from .pills import badges as badges_pills
+from .simple import badge as badges_simple
+from .size import badges as badges_size
 
 HERE = Path(__file__).parent
 
-badges_source = (HERE / "badge.py").read_text()
+badges_simple_source = (HERE / "simple.py").read_text()
+badges_size_source = (HERE / "size.py").read_text()
+badges_color_source = (HERE / "color.py").read_text()
+badges_pills_source = (HERE / "pills.py").read_text()
+badges_links_source = (HERE / "links.py").read_text()
 
 content = [
-    html.H2("Badge"),
-    ExampleContainer(badges),
-    HighlightedSource(badges_source),
+    html.H2("Badges", className="display-4"),
+    html.P(
+        dcc.Markdown(
+            "Documentation and examples for how to use Bootstrap "
+            "badges with *dash-bootstrap-components*."
+        ),
+        className="lead",
+    ),
+    html.H4("Simple example"),
+    html.P(
+        dcc.Markdown(
+            "Badges can be used as part of buttons or links to provide a "
+            "counter."
+        )
+    ),
+    ExampleContainer(badges_simple),
+    HighlightedSource(badges_simple_source),
+    html.H4("Badge sizing"),
+    html.P(
+        dcc.Markdown(
+            "Badges scale to match the size of their parent by using relative "
+            "font sizing."
+        )
+    ),
+    ExampleContainer(badges_size),
+    HighlightedSource(badges_size_source),
+    html.H4("Contextual variations"),
+    html.P(
+        dcc.Markdown(
+            "Use the `color` argument to apply one of Bootstrap's contextual "
+            "color classes."
+        )
+    ),
+    ExampleContainer(badges_color),
+    HighlightedSource(badges_color_source),
+    html.H4("Pill badges"),
+    html.P(
+        dcc.Markdown(
+            "Set `pill=True` to make the badges more rounded (with a larger "
+            "`border-radius` and additional horizontal padding)."
+        )
+    ),
+    ExampleContainer(badges_pills),
+    HighlightedSource(badges_pills_source),
+    html.H4("Links"),
+    html.P(
+        dcc.Markdown(
+            "Add a link with the `href` argument to create actionable badges "
+            "with hover and focus states."
+        )
+    ),
+    ExampleContainer(badges_links),
+    HighlightedSource(badges_links_source),
     ApiDoc(get_component_metadata("src/components/Badge.js")),
 ]

--- a/docs/components_page/components/badge/badge.py
+++ b/docs/components_page/components/badge/badge.py
@@ -1,6 +1,0 @@
-import dash_bootstrap_components as dbc
-import dash_html_components as html
-
-badges = html.H3(
-    ["This is a heading with a badge! ", dbc.Badge("New!", color="success")]
-)

--- a/docs/components_page/components/badge/color.py
+++ b/docs/components_page/components/badge/color.py
@@ -1,0 +1,15 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+badges = html.Span(
+    [
+        dbc.Badge("Primary", color="primary", className="mr-1"),
+        dbc.Badge("Secondary", color="secondary", className="mr-1"),
+        dbc.Badge("Success", color="success", className="mr-1"),
+        dbc.Badge("Warning", color="warning", className="mr-1"),
+        dbc.Badge("Danger", color="danger", className="mr-1"),
+        dbc.Badge("Info", color="info", className="mr-1"),
+        dbc.Badge("Light", color="light", className="mr-1"),
+        dbc.Badge("Dark", color="dark"),
+    ]
+)

--- a/docs/components_page/components/badge/links.py
+++ b/docs/components_page/components/badge/links.py
@@ -1,0 +1,15 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+badges = html.Span(
+    [
+        dbc.Badge("Primary", href="#", color="primary", className="mr-1"),
+        dbc.Badge("Secondary", href="#", color="secondary", className="mr-1"),
+        dbc.Badge("Success", href="#", color="success", className="mr-1"),
+        dbc.Badge("Warning", href="#", color="warning", className="mr-1"),
+        dbc.Badge("Danger", href="#", color="danger", className="mr-1"),
+        dbc.Badge("Info", href="#", color="info", className="mr-1"),
+        dbc.Badge("Light", href="#", color="light", className="mr-1"),
+        dbc.Badge("Dark", href="#", color="dark"),
+    ]
+)

--- a/docs/components_page/components/badge/pills.py
+++ b/docs/components_page/components/badge/pills.py
@@ -1,0 +1,15 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+badges = html.Span(
+    [
+        dbc.Badge("Primary", pill=True, color="primary", className="mr-1"),
+        dbc.Badge("Secondary", pill=True, color="secondary", className="mr-1"),
+        dbc.Badge("Success", pill=True, color="success", className="mr-1"),
+        dbc.Badge("Warning", pill=True, color="warning", className="mr-1"),
+        dbc.Badge("Danger", pill=True, color="danger", className="mr-1"),
+        dbc.Badge("Info", pill=True, color="info", className="mr-1"),
+        dbc.Badge("Light", pill=True, color="light", className="mr-1"),
+        dbc.Badge("Dark", pill=True, color="dark"),
+    ]
+)

--- a/docs/components_page/components/badge/simple.py
+++ b/docs/components_page/components/badge/simple.py
@@ -1,0 +1,6 @@
+import dash_bootstrap_components as dbc
+
+badge = dbc.Button(
+    ["Notifications", dbc.Badge("4", color="light", className="ml-1")],
+    color="primary",
+)

--- a/docs/components_page/components/badge/size.py
+++ b/docs/components_page/components/badge/size.py
@@ -1,0 +1,13 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+badges = html.Div(
+    [
+        html.H1(["Example heading", dbc.Badge("New", className="ml-1")]),
+        html.H2(["Example heading", dbc.Badge("New", className="ml-1")]),
+        html.H3(["Example heading", dbc.Badge("New", className="ml-1")]),
+        html.H4(["Example heading", dbc.Badge("New", className="ml-1")]),
+        html.H5(["Example heading", dbc.Badge("New", className="ml-1")]),
+        html.H6(["Example heading", dbc.Badge("New", className="ml-1")]),
+    ]
+)


### PR DESCRIPTION
This PR improves the documentation of `Badge`, taking a lot of cues from the [Bootstrap documentation for badges](https://getbootstrap.com/docs/4.3/components/badge/).

![image](https://user-images.githubusercontent.com/15220906/55385902-1cb12380-5526-11e9-8775-4c0f2a9ed20b.png)
