### PR TITLE
Add / update links on PyPI landing page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ from setuptools import find_packages, setup
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+GITHUB_URL = "https://github.com/facultyai/dash-bootstrap-components/"
+
 
 def _get_version():
     """ Get version by parsing _version programmatically """
@@ -30,7 +32,11 @@ setup(
     license="Apache Software License",
     author="Faculty",
     author_email="opensource@faculty.ai",
-    url="https://github.com/facultyai/dash-bootstrap-components",
+    url="https://dash-bootstrap-components.opensource.faculty.ai/",
+    project_urls={
+        "Bug Reports": os.path.join(GITHUB_URL, "issues"),
+        "Source": GITHUB_URL,
+    },
     packages=find_packages(),
     install_requires=["dash>=0.40.0"],
     include_package_data=True,


### PR DESCRIPTION
This simple PR updates some of the links on the PyPI landing page. The homepage is now given as the documentation, while there are separate links to this repository (listed as "Source") and the issues page of this repository (listed as "Bug Reports" with a fun little bug icon next to it 😄).

The changes can be seen on [the landing page for prerelease 0.4.1a1](https://pypi.org/project/dash-bootstrap-components/0.4.1a1/).

![image](https://user-images.githubusercontent.com/15220906/56084849-889e6080-5e31-11e9-8b12-f8b8a088d4c6.png)
