### PR TITLE
Multi-page examples

### DIFF
--- a/examples/advanced-component-usage/graphs_in_tabs.py
+++ b/examples/advanced-component-usage/graphs_in_tabs.py
@@ -1,0 +1,91 @@
+"""
+A simple app demonstrating how to dynamically render tab content containing
+dcc.Graph components to ensure graphs get sized correctly. We also show how
+dcc.Store can be used to cache the results of an expensive graph generation
+process so that switching tabs is fast.
+"""
+import time
+
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+import numpy as np
+import plotly.graph_objs as go
+from dash.dependencies import Input, Output
+
+app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
+
+app.layout = dbc.Container(
+    [
+        dcc.Store(id="store"),
+        html.H1("Dynamically rendered tab content"),
+        html.Hr(),
+        dbc.Button(
+            "Regenerate graphs",
+            color="primary",
+            block=True,
+            id="button",
+            className="mb-3",
+        ),
+        dbc.Tabs(
+            [
+                dbc.Tab(label="Scatter", tab_id="scatter"),
+                dbc.Tab(label="Histograms", tab_id="histogram"),
+            ],
+            id="tabs",
+        ),
+        html.Div(id="tab-content", className="p-4"),
+    ]
+)
+
+
+@app.callback(
+    Output("tab-content", "children"),
+    [Input("tabs", "active_tab"), Input("store", "data")],
+)
+def render_tab_content(active_tab, data):
+    """
+    This callback takes the 'active_tab' property as input, as well as the
+    stored graphs, and renders the tab content depending on what the value of
+    'active_tab' is.
+    """
+    if active_tab == "scatter":
+        return dcc.Graph(figure=data["scatter"])
+    elif active_tab == "histogram":
+        return dbc.Row(
+            [
+                dbc.Col(dcc.Graph(figure=data["hist_1"]), width=6),
+                dbc.Col(dcc.Graph(figure=data["hist_2"]), width=6),
+            ]
+        )
+    return data
+
+
+@app.callback(Output("store", "data"), [Input("button", "n_clicks")])
+def generate_graphs(n):
+    """
+    This callback generates three simple graphs from random data.
+    """
+    if not n:
+        # generate empty graphs when app loads
+        return {k: go.Figure(data=[]) for k in ["scatter", "hist_1", "hist_2"]}
+
+    # simulate expensive graph generation process
+    time.sleep(2)
+
+    # generate 100 multivariate normal samples
+    data = np.random.multivariate_normal([0, 0], [[1, 0.5], [0.5, 1]], 100)
+
+    scatter = go.Figure(
+        data=[go.Scatter(x=data[:, 0], y=data[:, 1], mode="markers")]
+    )
+    hist_1 = go.Figure(data=[go.Histogram(x=data[:, 0])])
+    hist_2 = go.Figure(data=[go.Histogram(x=data[:, 1])])
+
+    # save figures in a dictionary for sending to the dcc.Store
+    return {"scatter": scatter, "hist_1": hist_1, "hist_2": hist_2}
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True, port=8888)

--- a/examples/multi-page-apps/README.md
+++ b/examples/multi-page-apps/README.md
@@ -1,0 +1,5 @@
+# Multi-page apps
+
+This directory contains some multi-page example apps, demonstrating how the
+navigation components in *dash-bootstrap-components* can be used to create easy
+to navigate dashboards.

--- a/examples/multi-page-apps/README.md
+++ b/examples/multi-page-apps/README.md
@@ -3,3 +3,30 @@
 This directory contains some multi-page example apps, demonstrating how the
 navigation components in *dash-bootstrap-components* can be used to create easy
 to navigate dashboards.
+
+## `navbar.py`
+
+This example creates a multipage app with a navbar for navigation. It uses a
+Dash callback to toggle the `active` property of the `NavLink` components,
+allowing users to easily see which page they are on.
+
+## `simple_sidebar.py`
+
+This example creates a simple sidebar with vertically stacked links for
+navigation. A callback is again used to set the `active` property of the
+`NavLink` components, with the "pill" style applied to the active link.
+
+## `sidebar-with-submenus`
+
+This is like the simple sidebar, but the navlinks are gathered into collapsible
+collections which can be hidden or revealed by clicking. The app uses chevron
+icons fontawesome to indicate that the collapsible elements can be expanded or
+collapsed.
+
+## `responsive-sidebar`
+
+This is also like the simple sidebar, but adapts to smaller screen sizes
+(either when the browser window is resized, or the app is viewed on a mobile
+device). On smaller screens, the sidebar becomes a top navbar with the links
+becoming collapsible. Visit a deployed version on a mobile device, or toggle
+the device toolbar in your browser's developer tools to check it out!

--- a/examples/multi-page-apps/navbar.py
+++ b/examples/multi-page-apps/navbar.py
@@ -1,0 +1,71 @@
+"""
+This app uses NavbarSimple to navigate between three different pages.
+
+dcc.Location is used to track the current location. There are two callbacks,
+one uses the current location to render the appropriate page content, the other
+uses the current location to toggle the "active" properties of the navigation
+links. This means the link corresponding to the current page appears active,
+indicating to the user which page they are looking at.
+
+For more details on building multi-page Dash applications, check out the Dash
+documentation: https://dash.plot.ly/urls
+"""
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
+
+app.layout = html.Div(
+    [
+        dcc.Location(id="url"),
+        dbc.NavbarSimple(
+            children=[
+                dbc.NavLink("Page 1", href="/page-1", id="page-1-link"),
+                dbc.NavLink("Page 2", href="/page-2", id="page-2-link"),
+                dbc.NavLink("Page 3", href="/page-3", id="page-3-link"),
+            ],
+            brand="Navbar with active links",
+            color="primary",
+            dark=True,
+        ),
+        dbc.Container(id="page-content", className="pt-4"),
+    ]
+)
+
+
+# this callback uses the current pathname to set the active state of the
+# corresponding nav link to true, allowing users to tell see page they are on
+@app.callback(
+    [Output(f"page-{i}-link", "active") for i in range(1, 4)],
+    [Input("url", "pathname")],
+)
+def toggle_active_links(pathname):
+    if pathname == "/":
+        # Treat page 1 as the homepage / index
+        return True, False, False
+    return [pathname == f"/page-{i}" for i in range(1, 4)]
+
+
+@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+def render_page_content(pathname):
+    if pathname in ["/", "/page-1"]:
+        return html.P("This is the content of page 1!")
+    elif pathname == "/page-2":
+        return html.P("This is the content of page 2. Yay!")
+    elif pathname == "/page-3":
+        return html.P("Oh cool, this is page 3!")
+    # If the user tries to reach a different page, return a 404 message
+    return dbc.Jumbotron(
+        [
+            html.H1("404: Not found", className="text-danger"),
+            html.Hr(),
+            html.P(f"The pathname {pathname} was not recognised..."),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888)

--- a/examples/multi-page-apps/responsive-sidebar/assets/responsive-sidebar.css
+++ b/examples/multi-page-apps/responsive-sidebar/assets/responsive-sidebar.css
@@ -1,0 +1,61 @@
+#sidebar {
+  text-align: center;
+  padding: 2rem 1rem;
+  background-color: #f8f9fa;
+}
+
+#sidebar h2 {
+  text-align: left;
+}
+
+/* Hide the blurb on a small screen */
+#blurb {
+  display: none;
+}
+
+#collapse {
+  margin-top: 1rem;
+}
+
+@media (min-width: 48em) {
+  #sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 16rem;
+    text-align: left;
+  }
+
+  /* reveal the blurb on a large screen */
+  #blurb {
+    display: block;
+  }
+
+  /* Hide the toggle on a large screen */
+  #toggle {
+    display: none;
+  }
+
+  #collapse {
+    display: block;
+    margin-top: 0;
+  }
+}
+
+/* add the three horizontal bars icon for the toggle */
+.navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+#page-content {
+  padding: 2rem 1rem;
+}
+
+@media (min-width: 48em) {
+  /* set margins of the main content so that it doesn't overlap the sidebar */
+  #page-content {
+    margin-left: 18rem;
+    margin-right: 2rem;
+  }
+}

--- a/examples/multi-page-apps/responsive-sidebar/sidebar.py
+++ b/examples/multi-page-apps/responsive-sidebar/sidebar.py
@@ -1,0 +1,140 @@
+"""
+This app creates a responsive sidebar layout with dash-bootstrap-components and
+some custom css with media queries.
+
+When the screen is small, the sidebar moved to the top of the page, and the
+links get hidden in a collapse element. We use a callback to toggle the
+collapse when on a small screen, and the custom CSS to hide the toggle, and
+force the collapse to stay open when the screen is large.
+
+dcc.Location is used to track the current location. There are two callbacks,
+one uses the current location to render the appropriate page content, the other
+uses the current location to toggle the "active" properties of the navigation
+links.
+
+For more details on building multi-page Dash applications, check out the Dash
+documentation: https://dash.plot.ly/urls
+"""
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+
+app = dash.Dash(
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
+    # these meta_tags ensure content is scaled correctly on different devices
+    # see: https://www.w3schools.com/css/css_rwd_viewport.asp for more
+    meta_tags=[
+        {"name": "viewport", "content": "width=device-width, initial-scale=1"}
+    ],
+)
+
+# we use the Row and Col components to construct the sidebar header
+# it consists of a title, and a toggle, the latter is hidden on large screens
+sidebar_header = dbc.Row(
+    [
+        dbc.Col(html.H2("Sidebar", className="display-4")),
+        dbc.Col(
+            html.Button(
+                # use the Bootstrap navbar-toggler classes to style the toggle
+                html.Span(className="navbar-toggler-icon"),
+                className="navbar-toggler",
+                # the navbar-toggler classes don't set color, so we do it here
+                style={
+                    "color": "rgba(0,0,0,.5)",
+                    "border-color": "rgba(0,0,0,.1)",
+                },
+                id="toggle",
+            ),
+            # the column containing the toggle will be only as wide as the
+            # toggle, resulting in the toggle being right aligned
+            width="auto",
+            # vertically align the toggle in the center
+            align="center",
+        ),
+    ]
+)
+
+sidebar = html.Div(
+    [
+        sidebar_header,
+        # we wrap the horizontal rule and short blurb in a div that can be
+        # hidden on a small screen
+        html.Div(
+            [
+                html.Hr(),
+                html.P(
+                    "A responsive sidebar layout with collapsible navigation "
+                    "links.",
+                    className="lead",
+                ),
+            ],
+            id="blurb",
+        ),
+        # use the Collapse component to animate hiding / revealing links
+        dbc.Collapse(
+            dbc.Nav(
+                [
+                    dbc.NavLink("Page 1", href="/page-1", id="page-1-link"),
+                    dbc.NavLink("Page 2", href="/page-2", id="page-2-link"),
+                    dbc.NavLink("Page 3", href="/page-3", id="page-3-link"),
+                ],
+                vertical=True,
+                pills=True,
+            ),
+            id="collapse",
+        ),
+    ],
+    id="sidebar",
+)
+
+content = html.Div(id="page-content")
+
+app.layout = html.Div([dcc.Location(id="url"), sidebar, content])
+
+
+# this callback uses the current pathname to set the active state of the
+# corresponding nav link to true, allowing users to tell see page they are on
+@app.callback(
+    [Output(f"page-{i}-link", "active") for i in range(1, 4)],
+    [Input("url", "pathname")],
+)
+def toggle_active_links(pathname):
+    if pathname == "/":
+        # Treat page 1 as the homepage / index
+        return True, False, False
+    return [pathname == f"/page-{i}" for i in range(1, 4)]
+
+
+@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+def render_page_content(pathname):
+    if pathname in ["/", "/page-1"]:
+        return html.P("This is the content of page 1!")
+    elif pathname == "/page-2":
+        return html.P("This is the content of page 2. Yay!")
+    elif pathname == "/page-3":
+        return html.P("Oh cool, this is page 3!")
+    # If the user tries to reach a different page, return a 404 message
+    return dbc.Jumbotron(
+        [
+            html.H1("404: Not found", className="text-danger"),
+            html.Hr(),
+            html.P(f"The pathname {pathname} was not recognised..."),
+        ]
+    )
+
+
+@app.callback(
+    Output("collapse", "is_open"),
+    [Input("toggle", "n_clicks")],
+    [State("collapse", "is_open")],
+)
+def toggle_collapse(n, is_open):
+    if n:
+        return not is_open
+    return is_open
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888, debug=True)

--- a/examples/multi-page-apps/sidebar-with-submenus/assets/sidebar-with-submenus.css
+++ b/examples/multi-page-apps/sidebar-with-submenus/assets/sidebar-with-submenus.css
@@ -1,0 +1,12 @@
+.fa-chevron-right {
+  transition: transform 0.2s ease-in-out 0s;
+}
+
+/* rotate the chevron when the open class is applied */
+li.open .fa-chevron-right {
+  transform: rotate(90deg);
+}
+
+.nav li {
+  font-size: 18px;
+}

--- a/examples/multi-page-apps/sidebar-with-submenus/sidebar.py
+++ b/examples/multi-page-apps/sidebar-with-submenus/sidebar.py
@@ -1,0 +1,156 @@
+"""
+This app creates a simple sidebar layout using inline style arguments and the
+dbc.Nav component.
+
+dcc.Location is used to track the current location. There are two callbacks,
+one uses the current location to render the appropriate page content, the other
+uses the current location to toggle the "active" properties of the navigation
+links.
+
+For more details on building multi-page Dash applications, check out the Dash
+documentation: https://dash.plot.ly/urls
+"""
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+
+# link fontawesome to get the chevron icons
+FA = "https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+
+app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP, FA])
+
+# the style arguments for the sidebar. We use position:fixed and a fixed width
+SIDEBAR_STYLE = {
+    "position": "fixed",
+    "top": 0,
+    "left": 0,
+    "bottom": 0,
+    "width": "16rem",
+    "padding": "2rem 1rem",
+    "background-color": "#f8f9fa",
+}
+
+# the styles for the main content position it to the right of the sidebar and
+# add some padding.
+CONTENT_STYLE = {
+    "margin-left": "18rem",
+    "margin-right": "2rem",
+    "padding": "2rem 1rem",
+}
+
+submenu_1 = [
+    html.Li(
+        # use Row and Col components to position the chevrons
+        dbc.Row(
+            [
+                dbc.Col("Menu 1"),
+                dbc.Col(
+                    html.I(className="fas fa-chevron-right mr-3"), width="auto"
+                ),
+            ],
+            className="my-1",
+        ),
+        id="submenu-1",
+    ),
+    # we use the Collapse component to hide and reveal the navigation links
+    dbc.Collapse(
+        [
+            dbc.NavLink("Page 1.1", href="/page-1/1"),
+            dbc.NavLink("Page 1.2", href="/page-1/2"),
+        ],
+        id="submenu-1-collapse",
+    ),
+]
+
+submenu_2 = [
+    html.Li(
+        dbc.Row(
+            [
+                dbc.Col("Menu 2"),
+                dbc.Col(
+                    html.I(className="fas fa-chevron-right mr-3"), width="auto"
+                ),
+            ],
+            className="my-1",
+        ),
+        id="submenu-2",
+    ),
+    dbc.Collapse(
+        [
+            dbc.NavLink("Page 2.1", href="/page-2/1"),
+            dbc.NavLink("Page 2.2", href="/page-2/2"),
+        ],
+        id="submenu-2-collapse",
+    ),
+]
+
+
+sidebar = html.Div(
+    [
+        html.H2("Sidebar", className="display-4"),
+        html.Hr(),
+        html.P(
+            "A sidebar with collapsible navigation links", className="lead"
+        ),
+        dbc.Nav(submenu_1 + submenu_2, vertical=True),
+    ],
+    style=SIDEBAR_STYLE,
+    id="sidebar",
+)
+
+content = html.Div(id="page-content", style=CONTENT_STYLE)
+
+app.layout = html.Div([dcc.Location(id="url"), sidebar, content])
+
+
+# this function is used to toggle the is_open property of each Collapse
+def toggle_collapse(n, is_open):
+    if n:
+        return not is_open
+    return is_open
+
+
+# this function applies the "open" class to rotate the chevron
+def set_navitem_class(is_open):
+    if is_open:
+        return "open"
+    return ""
+
+
+for i in [1, 2]:
+    app.callback(
+        Output(f"submenu-{i}-collapse", "is_open"),
+        [Input(f"submenu-{i}", "n_clicks")],
+        [State(f"submenu-{i}-collapse", "is_open")],
+    )(toggle_collapse)
+
+    app.callback(
+        Output(f"submenu-{i}", "className"),
+        [Input(f"submenu-{i}-collapse", "is_open")],
+    )(set_navitem_class)
+
+
+@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+def render_page_content(pathname):
+    if pathname in ["/", "/page-1/1"]:
+        return html.P("This is the content of page 1.1!")
+    elif pathname == "/page-1/2":
+        return html.P("This is the content of page 1.2. Yay!")
+    elif pathname == "/page-2/1":
+        return html.P("Oh cool, this is page 2.1!")
+    elif pathname == "/page-2/2":
+        return html.P("No way! This is page 2.2!")
+    # If the user tries to reach a different page, return a 404 message
+    return dbc.Jumbotron(
+        [
+            html.H1("404: Not found", className="text-danger"),
+            html.Hr(),
+            html.P(f"The pathname {pathname} was not recognised..."),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888, debug=True)

--- a/examples/multi-page-apps/simple_sidebar.py
+++ b/examples/multi-page-apps/simple_sidebar.py
@@ -1,0 +1,97 @@
+"""
+This app creates a simple sidebar layout using inline style arguments and the
+dbc.Nav component.
+
+dcc.Location is used to track the current location. There are two callbacks,
+one uses the current location to render the appropriate page content, the other
+uses the current location to toggle the "active" properties of the navigation
+links.
+
+For more details on building multi-page Dash applications, check out the Dash
+documentation: https://dash.plot.ly/urls
+"""
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
+
+# the style arguments for the sidebar. We use position:fixed and a fixed width
+SIDEBAR_STYLE = {
+    "position": "fixed",
+    "top": 0,
+    "left": 0,
+    "bottom": 0,
+    "width": "16rem",
+    "padding": "2rem 1rem",
+    "background-color": "#f8f9fa",
+}
+
+# the styles for the main content position it to the right of the sidebar and
+# add some padding.
+CONTENT_STYLE = {
+    "margin-left": "18rem",
+    "margin-right": "2rem",
+    "padding": "2rem 1rem",
+}
+
+sidebar = html.Div(
+    [
+        html.H2("Sidebar", className="display-4"),
+        html.Hr(),
+        html.P(
+            "A simple sidebar layout with navigation links", className="lead"
+        ),
+        dbc.Nav(
+            [
+                dbc.NavLink("Page 1", href="/page-1", id="page-1-link"),
+                dbc.NavLink("Page 2", href="/page-2", id="page-2-link"),
+                dbc.NavLink("Page 3", href="/page-3", id="page-3-link"),
+            ],
+            vertical=True,
+            pills=True,
+        ),
+    ],
+    style=SIDEBAR_STYLE,
+)
+
+content = html.Div(id="page-content", style=CONTENT_STYLE)
+
+app.layout = html.Div([dcc.Location(id="url"), sidebar, content])
+
+
+# this callback uses the current pathname to set the active state of the
+# corresponding nav link to true, allowing users to tell see page they are on
+@app.callback(
+    [Output(f"page-{i}-link", "active") for i in range(1, 4)],
+    [Input("url", "pathname")],
+)
+def toggle_active_links(pathname):
+    if pathname == "/":
+        # Treat page 1 as the homepage / index
+        return True, False, False
+    return [pathname == f"/page-{i}" for i in range(1, 4)]
+
+
+@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+def render_page_content(pathname):
+    if pathname in ["/", "/page-1"]:
+        return html.P("This is the content of page 1!")
+    elif pathname == "/page-2":
+        return html.P("This is the content of page 2. Yay!")
+    elif pathname == "/page-3":
+        return html.P("Oh cool, this is page 3!")
+    # If the user tries to reach a different page, return a 404 message
+    return dbc.Jumbotron(
+        [
+            html.H1("404: Not found", className="text-danger"),
+            html.Hr(),
+            html.P(f"The pathname {pathname} was not recognised..."),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888)


### PR DESCRIPTION
This PR adds multiple new examples including:

An example demonstrating how to dynamically render tab content to ensure `dash_core_components.Graph` components are sized correctly. This is a common pitfall, so good to have a linkable solution.

Multiple layout examples for multi-page apps.

`navbar.py` - A simple multipage app using `NavbarSimple`:

![image](https://user-images.githubusercontent.com/15220906/56438951-7c584e80-62dc-11e9-8d74-cc338f4b8917.png)

`simple_sidebar.py` - A simple sidebar using `Nav`

![image](https://user-images.githubusercontent.com/15220906/56438998-9b56e080-62dc-11e9-8c70-fc1c4fda3b7c.png)

`sidebar-with-submenus` - A sidebar with collapsible submenus, which uses fontawesome to make animated chevrons.

![image](https://user-images.githubusercontent.com/15220906/56439083-d1946000-62dc-11e9-9b29-62ba12af002a.png)


`responsive-sidebar` - A responsive sidebar layout that reorganises itself on smaller screens

![image](https://user-images.githubusercontent.com/15220906/56439141-fee10e00-62dc-11e9-908b-8a9c2b2b5da6.png)


