### PR TITLE
Input props updates

### DIFF
--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -182,14 +182,14 @@ Input.propTypes = {
    * This attribute indicates whether the value of the control can be
    * automatically completed by the browser.
    */
-  autocomplete: PropTypes.string,
+  autoComplete: PropTypes.string,
 
   /**
    * The element should be automatically focused after the page has loaded.
    */
-  autofocus: PropTypes.string,
+  autoFocus: PropTypes.string,
 
-  inputmode: PropTypes.oneOf([
+  inputMode: PropTypes.oneOf([
     /**
      * Alphanumeric, non-prose content such as usernames and passwords.
      */
@@ -281,7 +281,7 @@ Input.propTypes = {
    * user can enter an unlimited number of characters). The constraint is
    * evaluated only when the value of the attribute has been changed.
    */
-  maxlength: PropTypes.string,
+  maxLength: PropTypes.string,
 
   /**
    * The minimum (numeric or date-time) value for this item, which must not be
@@ -295,7 +295,7 @@ Input.propTypes = {
    * Unicode code points) that the user can enter. For other control types, it
    * is ignored.
    */
-  minlength: PropTypes.string,
+  minLength: PropTypes.string,
 
   /**
    * Works with the min and max attributes to limit the increments at which a

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -76,7 +76,7 @@ class Input extends React.Component {
           if (setProps) {
             const payload = {
               n_blur: this.props.n_blur + 1,
-              n_blur_timestamp: new Date()
+              n_blur_timestamp: Date.now()
             };
             if (debounce) {
               payload.value = type === 'number' ? Number(value) : value;
@@ -88,7 +88,7 @@ class Input extends React.Component {
           if (setProps && e.key === 'Enter') {
             const payload = {
               n_submit: this.props.n_submit + 1,
-              n_submit_timestamp: new Date()
+              n_submit_timestamp: Date.now()
             };
             if (debounce) {
               payload.value = type === 'number' ? Number(value) : value;

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -54,7 +54,7 @@ class Textarea extends React.Component {
           if (setProps) {
             const payload = {
               n_blur: this.props.n_blur + 1,
-              n_blur_timestamp: new Date()
+              n_blur_timestamp: Date.now()
             };
             if (debounce) {
               payload.value = value;
@@ -66,7 +66,7 @@ class Textarea extends React.Component {
           if (setProps) {
             setProps({
               n_clicks: this.props.n_clicks + 1,
-              n_clicks_timestamp: new Date()
+              n_clicks_timestamp: Date.now()
             });
           }
         }}

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -77,13 +77,16 @@ describe('Input', () => {
         />
       )
       const htmlInput = input.find('input')
+      const before = Date.now()
       htmlInput.simulate('blur')
+      const after = Date.now()
       expect(setProps.mock.calls).toHaveLength(1)
       const [call] = setProps.mock.calls
       const [arg] = call
       const { n_blur, n_blur_timestamp } = arg
       expect(n_blur).toEqual(1)
-      expect(n_blur_timestamp).toBeValidDate()
+      expect(n_blur_timestamp).toBeGreaterThanOrEqual(before)
+      expect(n_blur_timestamp).toBeLessThanOrEqual(after)
     })
 
     it('dispatch the value if debounce is true', () => {
@@ -98,13 +101,16 @@ describe('Input', () => {
         />
       )
       const htmlInput = input.find('input')
+      const before = Date.now()
       htmlInput.simulate('blur')
+      const after = Date.now()
       expect(setProps.mock.calls).toHaveLength(1)
       const [call] = setProps.mock.calls
       const [arg] = call
       const { n_blur, n_blur_timestamp, value } = arg
       expect(n_blur).toEqual(1)
-      expect(n_blur_timestamp).toBeValidDate()
+      expect(n_blur_timestamp).toBeGreaterThanOrEqual(before)
+      expect(n_blur_timestamp).toBeLessThanOrEqual(after)
       expect(value).toEqual('some-value')
     })
   })
@@ -121,11 +127,14 @@ describe('Input', () => {
           setProps={setProps}
         />
       )
+      const before = Date.now()
       input.simulate('keyPress', event)
+      const after = Date.now()
       expect(setProps.mock.calls).toHaveLength(1)
       const [[{n_submit, n_submit_timestamp}]] = setProps.mock.calls
       expect(n_submit).toEqual(1)
-      expect(n_submit_timestamp).toBeValidDate()
+      expect(n_submit_timestamp).toBeGreaterThanOrEqual(before)
+      expect(n_submit_timestamp).toBeLessThanOrEqual(after)
     })
 
     it('dispatch the value if debounce is true', () => {
@@ -139,11 +148,14 @@ describe('Input', () => {
           value="some-value"
         />
       )
+      const before = Date.now()
       input.simulate('keyPress', event)
+      const after = Date.now()
       expect(setProps.mock.calls).toHaveLength(1)
       const [[{n_submit, n_submit_timestamp, value}]] = setProps.mock.calls
       expect(n_submit).toEqual(1)
-      expect(n_submit_timestamp).toBeValidDate()
+      expect(n_submit_timestamp).toBeGreaterThanOrEqual(before)
+      expect(n_submit_timestamp).toBeLessThanOrEqual(after)
       expect(value).toEqual("some-value")
     })
 


### PR DESCRIPTION
This PR makes two changes:

1) Some props of `Input` that map to HTML attributes were previously not camel cased and hence not applied correctly. While we could have built some kind of shim to pass these down to the underlying HTML elements, *dash-core-components* chose to rename them, and I think it makes sense to stay consistent with them. See [their changelog](https://github.com/plotly/dash-core-components/blob/master/CHANGELOG.md#0470---2019-04-25)

2) Use timestamp rather than date object in `*_timestamp` props in `Input`.