### PR TITLE
Reenable dropup

### DIFF
--- a/docs/components_page/components/dropdown/direction.py
+++ b/docs/components_page/components/dropdown/direction.py
@@ -11,17 +11,25 @@ dropdown = dbc.Row(
         dbc.Col(
             dbc.DropdownMenu(
                 label="Dropdown (default)", children=items, direction="down"
-            )
+            ),
+            width="auto",
         ),
         dbc.Col(
             dbc.DropdownMenu(
                 label="Dropleft", children=items, direction="left"
-            )
+            ),
+            width="auto",
         ),
         dbc.Col(
             dbc.DropdownMenu(
                 label="Dropright", children=items, direction="right"
-            )
+            ),
+            width="auto",
         ),
-    ]
+        dbc.Col(
+            dbc.DropdownMenu(label="Dropup", children=items, direction="up"),
+            width="auto",
+        ),
+    ],
+    justify="between",
 )

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -99,10 +99,9 @@ DropdownMenu.propTypes = {
   label: PropTypes.string,
 
   /**
-   * Direction in which to expand the DropdownMenu. Note that expanding
-   * the DropdownMenu upwards is currently unsupported. Default: 'down'.
+   * Direction in which to expand the DropdownMenu. Default: 'down'.
    */
-  direction: PropTypes.oneOf(['down', 'left', 'right']),
+  direction: PropTypes.oneOf(['down', 'left', 'right', 'up']),
 
   /**
    * Align the DropdownMenu along the right side of its parent. Default: False.


### PR DESCRIPTION
This PR addresses #65, re-enabling direction=up in `DropdownMenu` and adding a dropup to the `DropdownMenu` docs.