### PR TITLE
Add stretch and baseline options to align for Row and Col

### DIFF
--- a/src/components/layout/Col.js
+++ b/src/components/layout/Col.js
@@ -6,7 +6,9 @@ import classNames from 'classnames';
 const alignMap = {
   start: 'align-self-start',
   center: 'align-self-center',
-  end: 'align-self-end'
+  end: 'align-self-end',
+  stretch: 'align-self-stretch',
+  baseline: 'align-self-baseline'
 };
 
 const Col = props => {
@@ -147,9 +149,9 @@ Col.propTypes = {
 
   /**
    * Set vertical alignment of this column's content in the parent row. Options
-   * are 'start', 'center', 'end'.
+   * are 'start', 'center', 'end', 'stretch', 'baseline'.
    */
-  align: PropTypes.oneOf(['start', 'center', 'end']),
+  align: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/layout/Row.js
+++ b/src/components/layout/Row.js
@@ -6,7 +6,9 @@ import classNames from 'classnames';
 const alignMap = {
   start: 'align-items-start',
   center: 'align-items-center',
-  end: 'align-items-end'
+  end: 'align-items-end',
+  stretch: 'align-items-stretch',
+  baseline: 'align-items-baseline'
 };
 
 const justifyMap = {
@@ -84,9 +86,9 @@ Row.propTypes = {
 
   /**
    * Set vertical alignment of columns in this row. Options are 'start',
-   * 'center' and 'end'.
+   * 'center', 'end', 'stretch' and 'baseline'.
    */
-  align: PropTypes.oneOf(['start', 'center', 'end']),
+  align: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
   /**
    * Set horizontal spacing and alignment of columns in this row. Options are


### PR DESCRIPTION
This PR addresses #203 by supporting `"stretch"` and `"baseline"` as options to the align prop in both `Row` and `Col` components.

Documentation will follow in an upcoming refresh of the layout component documentation.