### PR TITLE
Fix border radius on example containers in docs

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -91,11 +91,11 @@ span.hljs-meta {
   margin-bottom: 2rem;
 }
 
-.example-source-container>pre.hljs {
+.example-source-container pre.hljs {
   border-radius: 0px 0px 3px 3px;
 }
 
-.source-container>pre.hljs {
+.source-container pre.hljs {
   border-radius: 3px;
 }
 


### PR DESCRIPTION
This small PR fixes the border radius on example containers in the docs. It broke because `SyntaxHighlighter` from *dash-core-components* now renders an extra `div` element in order to support the loading states API, which mean our CSS selector no longer applied.