### PR TITLE
Make active_tab prop of Tabs settable

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -59,12 +59,21 @@ class Tabs extends React.Component {
   }
 
   toggle(tab) {
-    if (this.state.activeTab !== tab) {
-      this.setState({activeTab: tab});
-      if (this.props.setProps) {
+    if (this.props.setProps) {
+      if (this.props.active_tab !== tab) {
         this.props.setProps({active_tab: tab});
       }
+    } else {
+      if (this.state.activeTab !== tab) {
+        this.setState({activeTab: tab});
+      }
     }
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.active_tab && nextProps.active_tab != prevState.activeTab) {
+      return {activeTab: nextProps.active_tab};
+    } else return null;
   }
 
   render() {

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -190,8 +190,9 @@ Tabs.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Determine which tab is currently showing. Will be the id of the tab or
-   * 'tab-i' where i is the index of the tab (indexed from zero)
+   * The tab_id of the currently active tab. If tab_id has not been specified
+   * for the active tab, this will default to tab-i, where i is the index
+   * (starting from 0) of the tab.
    */
   active_tab: PropTypes.string,
 


### PR DESCRIPTION
This PR addresses #212. 

Previously `Tabs` would just report which tab was currently active, allowing you to render content dynamically with Dash callbacks when the active tab changed. It was not however possible to change the active tab using a callback. The changes in this pull request fix that, allowing switching of tabs by setting the `active_tab` prop appropriately.

Here is a simple example:

```python
import dash
import dash_bootstrap_components as dbc
import dash_html_components as html
from dash.dependencies import Input, Output, State

app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])

app.layout = dbc.Container(
    dbc.Tabs(
        [
            dbc.Tab(
                dbc.Button("Go to tab 2", id="tab-1-button"),
                className="p-3",
                label="Tab 1",
                tab_id="tab-1",
            ),
            dbc.Tab(html.P("This is tab 2"), label="Tab 2", tab_id="tab-2"),
        ],
        id="tabs",
    ),
    className="p-5",
)


@app.callback(
    # Button: switch to Tab 2
    Output("tabs", "active_tab"),
    [Input("tab-1-button", "n_clicks")],
    [State("tabs", "active_tab")],
)
def set_tab(n, prev_active):
    if n:
        return "tab-2"
    return prev_active


if __name__ == "__main__":
    app.run_server(debug=True, port=8888)

```