### PR TITLE
Conda instructions

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -36,11 +36,11 @@
           <hr />
           <h4 class="section-header">PyPI</h4>
           <p>
-            You can install <em>dash-bootstrap-components</em> with pip:
+            You can install <em>dash-bootstrap-components</em> with <code>pip</code>:
           </p>
           <pre><code class="language-bash">pip install dash-bootstrap-components</code> </pre>
           <h4 class="section-header">Anaconda</h4>
-          <p>Anaconda users can install <em>dash-bootstrap-components</em> through the conda-forge channel</p>
+          <p>You can also install <em>dash-bootstrap-components</em> with <code>conda</code> through the conda-forge channel</p>
           <pre><code class="language-bash">conda install -c conda-forge dash-bootstrap-components</code></pre>
           <h2 class="section-header mt-5">Getting started</h2>
           <hr />

--- a/landing-page.md
+++ b/landing-page.md
@@ -10,11 +10,21 @@ components. It is built on top of [reactstrap][reactstrap-homepage].
 
 ## Installation
 
-*dash-bootstrap-components* is hosted on PyPI, and can be installed by
-running
+### PyPI
+
+You can install *dash-bootstrap-components* with `pip`:
 
 ```
 pip install dash-bootstrap-components
+```
+
+### Anaconda
+
+You can also install *dash-bootstrap-components* with `conda` through the
+conda-forge channel:
+
+```
+conda install -c conda-forge dash-bootstrap-components
 ```
 
 ## Documentation


### PR DESCRIPTION
Add missing conda installation instructions to PyPI landing page and tweak anaconda wording on docs homepage