### PR TITLE
Custom RadioItems and Checklist

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -14,7 +14,7 @@
   margin-right: 1rem;
 }
 
-.main-header .btn+.btn {
+.main-header .btn + .btn {
   margin-right: 0;
 }
 
@@ -61,12 +61,12 @@ span.hljs-meta {
 }
 
 .docs-sidebar .nav-item {
-  padding: 0 .2rem 0 .2rem;
+  padding: 0 0.2rem 0 0.2rem;
 }
 
 .docs-sidebar .nav-link {
   color: #888;
-  padding: .3rem .5rem .3rem 1rem;
+  padding: 0.3rem 0.5rem 0.3rem 1rem;
   border-left: 2px solid transparent;
 }
 
@@ -110,14 +110,13 @@ span.hljs-meta {
 
 .layout-demo .row {
   margin-bottom: 10px;
-  background: linear-gradient(to right,
-    rgba(0, 0, 0, 0),
-    rgba(0, 0, 0, 0) calc(100% - 15px),
-    #fff calc(100% - 15px)),
-    linear-gradient(to right,
-    #fff,
-    #fff 15px,
-    rgba(0, 0, 0, 0) 15px),
+  background: linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0),
+      rgba(0, 0, 0, 0) calc(100% - 15px),
+      #fff calc(100% - 15px)
+    ),
+    linear-gradient(to right, #fff, #fff 15px, rgba(0, 0, 0, 0) 15px),
     linear-gradient(to right, #eeeeee, #eeeeee);
 }
 
@@ -129,12 +128,21 @@ span.hljs-meta {
   height: 100px;
 }
 
-.layout-demo .col>div, .layout-demo [class*="col-"]>div {
+.layout-demo .col > div,
+.layout-demo [class*='col-'] > div {
   padding: 0.75rem;
-  background-color: rgba(86, 61, 124, .15);
-  border: 1px solid rgba(86, 61, 124, .2);
+  background-color: rgba(86, 61, 124, 0.15);
+  border: 1px solid rgba(86, 61, 124, 0.2);
 }
 
 ._dash-undo-redo {
   display: none;
+}
+
+/* Custom checkbox example CSS */
+#checklist-selected-style
+  .custom-control-input:checked
+  ~ .custom-control-label::before {
+  background-color: #fa7268;
+  border-color: #ea6258;
 }

--- a/docs/components_page/components/input/__init__.py
+++ b/docs/components_page/components/input/__init__.py
@@ -11,6 +11,7 @@ from ...helpers import (
 )
 from ...metadata import get_component_metadata
 from .radio_check_inline import inline_inputs
+from .selected_styles import checklist as input_selected_styles
 from .size import inputs as input_size
 from .text_label import text_input as input_text_label
 from .textarea import textareas as input_textarea
@@ -25,6 +26,7 @@ input_validation_source = (HERE / "validation.py").read_text()
 input_radio_check_source = (HERE / "radio_check.py").read_text()
 input_textarea_source = (HERE / "textarea.py").read_text()
 input_radio_check_inline_source = (HERE / "radio_check_inline.py").read_text()
+input_selected_styles_source = (HERE / "selected_styles.py").read_text()
 input_radio_check_standalone_source = (
     HERE / "radio_check_standalone.py"
 ).read_text()
@@ -32,7 +34,14 @@ input_radio_check_standalone_source = (
 
 def get_content(app):
     return [
-        html.H2("Input components"),
+        html.H2("Input components", className="display-4"),
+        html.P(
+            dcc.Markdown(
+                "Documentation and examples for input components in "
+                "_dash-bootstrap-components_."
+            ),
+            className="lead",
+        ),
         html.P(
             dcc.Markdown(
                 "*dash-bootstrap-components* has its own versions of some of "
@@ -59,16 +68,12 @@ def get_content(app):
         HighlightedSource(input_simple_source),
         html.H4("Labels and Text"),
         html.P(
-            [
-                dcc.Markdown(
-                    "Use the `FormGroup` component along with `Label` and "
-                    "`FormText` to control the layout of your `Input` "
-                    "components."
-                ),
-                "See the ",
-                dcc.Link("documentation for forms", href="/l/components/form"),
-                " for more details.",
-            ]
+            dcc.Markdown(
+                "Use the `FormGroup` component along with `Label` and "
+                "`FormText` to control the layout of your `Input` components. "
+                "See the [documentation for forms](/l/components/form) for "
+                "more details."
+            )
         ),
         ExampleContainer(input_text_label),
         HighlightedSource(input_text_label_source),
@@ -106,11 +111,21 @@ def get_content(app):
         html.P(
             dcc.Markdown(
                 "`RadioItems` and `Checklist` components also work like "
-                "*dash-core-components* but again with Bootstrap styles "
-                "added. In addition the `inline` keyword can be used to "
-                "easily make inline checklists or radioitems. Use these "
-                "components with `FormGroup` for automatic spacing and "
-                "padding."
+                "*dash-core-components*. Provided you specify an `id`, "
+                "_dash-bootstrap-components_ will render custom themed radio "
+                "buttons or checkboxes rather than using the native browser "
+                "buttons. When using `Checklist` you can also specify "
+                "`switch=True` to render toggle-like switches rather than "
+                "checkboxes. If you prefer to use the native buttons and "
+                "checkboxes, set `custom=False`. Note that there is no native "
+                "browser switch, so if you set `custom=False` then `switch` "
+                "will be ignored."
+            )
+        ),
+        html.P(
+            dcc.Markdown(
+                "Use these components with `FormGroup` for automatic spacing "
+                "and padding."
             )
         ),
         ExampleContainer(
@@ -127,15 +142,37 @@ def get_content(app):
         ),
         ExampleContainer(inline_inputs),
         HighlightedSource(input_radio_check_inline_source),
+        html.H4("Checked item styles"),
         html.P(
             dcc.Markdown(
-                "If you need more granular control over checkboxes "
-                "and radio buttons, you can also create standalone "
-                "components. Bind callbacks to the `checked` keyword "
-                "to react to changes in the input state. To attach "
-                "a label, create a FormGroup with `check=True` and "
-                "use the label's `html_for` keyword to bind it to "
-                "the checkbox."
+                "Use the `labelCheckedStyle` and `labelCheckedClassName` "
+                "arguments to apply different styles to the labels of checked "
+                "items. When using custom inputs you can override the styles "
+                "of the inputs using custom CSS. See the below example."
+            )
+        ),
+        dcc.Markdown(
+            """```css
+#checklist-selected-style
+  .custom-control-input:checked
+  ~ .custom-control-label::before {
+  background-color: #fa7268;
+  border-color: #ea6258;
+}
+
+```
+        """
+        ),
+        ExampleContainer(input_selected_styles),
+        HighlightedSource(input_selected_styles_source),
+        html.P(
+            dcc.Markdown(
+                "If you need more granular control over checkboxes and radio "
+                "buttons, you can also create standalone components. Bind "
+                "callbacks to the `checked` keyword to react to changes in "
+                "the input state. To attach a label, create a FormGroup with "
+                "`check=True` and use the label's `html_for` keyword to bind "
+                "it to the checkbox."
             )
         ),
         ExampleContainer(

--- a/docs/components_page/components/input/radio_check.py
+++ b/docs/components_page/components/input/radio_check.py
@@ -9,6 +9,7 @@ radioitems = dbc.FormGroup(
             options=[
                 {"label": "Option 1", "value": 1},
                 {"label": "Option 2", "value": 2},
+                {"label": "Disabled option", "value": 3, "disabled": True},
             ],
             value=1,
             id="radioitems-input",
@@ -23,6 +24,7 @@ checklist = dbc.FormGroup(
             options=[
                 {"label": "Option 1", "value": 1},
                 {"label": "Option 2", "value": 2},
+                {"label": "Disabled Option", "value": 3, "disabled": True},
             ],
             value=[],
             id="checklist-input",
@@ -30,9 +32,25 @@ checklist = dbc.FormGroup(
     ]
 )
 
+switches = dbc.FormGroup(
+    [
+        dbc.Label("Toggle a bunch"),
+        dbc.Checklist(
+            options=[
+                {"label": "Option 1", "value": 1},
+                {"label": "Option 2", "value": 2},
+                {"label": "Disabled Option", "value": 3, "disabled": True},
+            ],
+            value=[],
+            id="switches-input",
+            switch=True,
+        ),
+    ]
+)
+
 inputs = html.Div(
     [
-        dbc.Form([radioitems, checklist]),
+        dbc.Form([radioitems, checklist, switches]),
         html.P(id="radioitems-checklist-output"),
     ]
 )
@@ -40,9 +58,23 @@ inputs = html.Div(
 
 @app.callback(
     Output("radioitems-checklist-output", "children"),
-    [Input("radioitems-input", "value"), Input("checklist-input", "value")],
+    [
+        Input("radioitems-input", "value"),
+        Input("checklist-input", "value"),
+        Input("switches-input", "value"),
+    ],
 )
-def on_form_change(radio_items_value, checklist_value):
-    template = "Radio button {} and {} checklist items are selected."
-    output_string = template.format(radio_items_value, len(checklist_value))
+def on_form_change(radio_items_value, checklist_value, switches_value):
+    template = "Radio button {}, {} checklist item{} and {} switch{} selected."
+
+    n_checkboxes = len(checklist_value)
+    n_switches = len(switches_value)
+
+    output_string = template.format(
+        radio_items_value,
+        n_checkboxes,
+        "s" if n_checkboxes != 1 else "",
+        n_switches,
+        "es" if n_switches != 1 else "",
+    )
     return output_string

--- a/docs/components_page/components/input/radio_check_inline.py
+++ b/docs/components_page/components/input/radio_check_inline.py
@@ -9,6 +9,7 @@ inline_radioitems = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             value=1,
+            id="radioitems-inline-input",
             inline=True,
         ),
     ]
@@ -23,9 +24,28 @@ inline_checklist = dbc.FormGroup(
                 {"label": "Option 2", "value": 2},
             ],
             value=[],
+            id="checklist-inline-input",
             inline=True,
         ),
     ]
 )
 
-inline_inputs = dbc.Form([inline_radioitems, inline_checklist])
+inline_switches = dbc.FormGroup(
+    [
+        dbc.Label("Toggle a bunch"),
+        dbc.Checklist(
+            options=[
+                {"label": "Option 1", "value": 1},
+                {"label": "Option 2", "value": 2},
+            ],
+            value=[],
+            id="switches-inline-input",
+            inline=True,
+            switch=True,
+        ),
+    ]
+)
+
+inline_inputs = dbc.Form(
+    [inline_radioitems, inline_checklist, inline_switches]
+)

--- a/docs/components_page/components/input/selected_styles.py
+++ b/docs/components_page/components/input/selected_styles.py
@@ -1,0 +1,11 @@
+import dash_bootstrap_components as dbc
+
+checklist = dbc.Checklist(
+    id="checklist-selected-style",
+    options=[
+        {"label": "Option 1", "value": 1},
+        {"label": "Option 2", "value": 2},
+        {"label": "Option 3", "value": 3},
+    ],
+    labelCheckedStyle={"color": "red"},
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10091,9 +10091,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.assign": {
@@ -10143,9 +10143,9 @@
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -13184,7 +13184,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -240,7 +240,8 @@ Checklist.propTypes = {
   inline: PropTypes.bool,
 
   /**
-   * Set to True to render toggle-like switches instead of checkboxes.
+   * Set to True to render toggle-like switches instead of checkboxes. Ignored
+   * if custom=False
    */
   switch: PropTypes.bool,
 

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {append, contains, without} from 'ramda';
 import classNames from 'classnames';
+import CustomInput from '../../private/CustomInput';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
@@ -10,22 +11,119 @@ import classNames from 'classnames';
  * Each checkbox is rendered as an input with a surrounding label.
  */
 class Checklist extends React.Component {
-  render() {
+  constructor(props) {
+    super(props);
+
+    this.listItem = this.listItem.bind(this);
+  }
+
+  listItem(option) {
     const {
       className,
       id,
       inputClassName,
       inputStyle,
       labelClassName,
+      labelCheckedClassName,
       labelStyle,
+      labelCheckedStyle,
       options,
       setProps,
       style,
       inline,
       key,
       value,
-      loading_state
+      loading_state,
+      custom,
+      switch: switches
     } = this.props;
+
+    const checked = contains(option.value, value);
+
+    const mergedLabelStyle = checked
+      ? {...labelStyle, ...labelCheckedStyle}
+      : labelStyle;
+
+    if (id && custom) {
+      return (
+        <CustomInput
+          id={`_${id}-${option.value}`}
+          checked={checked}
+          className={inputClassName}
+          disabled={Boolean(option.disabled)}
+          type={switches ? 'switch' : 'checkbox'}
+          label={option.label}
+          labelStyle={mergedLabelStyle}
+          className={classNames(
+            labelClassName,
+            checked && labelCheckedClassName
+          )}
+          inline={inline}
+          onChange={() => {
+            let newValue;
+            if (contains(option.value, value)) {
+              newValue = without([option.value], value);
+            } else {
+              newValue = append(option.value, value);
+            }
+            setProps({value: newValue});
+          }}
+        />
+      );
+    } else {
+      return (
+        <div
+          className={classNames('form-check', inline && 'form-check-inline')}
+          key={option.value}
+        >
+          <input
+            checked={checked}
+            className={classNames('form-check-input', inputClassName)}
+            disabled={Boolean(option.disabled)}
+            style={inputStyle}
+            type="checkbox"
+            onChange={() => {
+              let newValue;
+              if (contains(option.value, value)) {
+                newValue = without([option.value], value);
+              } else {
+                newValue = append(option.value, value);
+              }
+              setProps({value: newValue});
+            }}
+          />
+          <label
+            style={mergedLabelStyle}
+            className={classNames(
+              'form-check-label',
+              labelClassName,
+              checked && labelCheckedClassName
+            )}
+            key={option.value}
+          >
+            {option.label}
+          </label>
+        </div>
+      );
+    }
+  }
+
+  render() {
+    const {
+      className,
+      id,
+      options,
+      style,
+      inline,
+      key,
+      loading_state,
+      custom,
+      switch: switches
+    } = this.props;
+
+    const items = options.map(option => (
+      <React.Fragment>{this.listItem(option)}</React.Fragment>
+    ));
 
     return (
       <div
@@ -37,36 +135,7 @@ class Checklist extends React.Component {
           (loading_state && loading_state.is_loading) || undefined
         }
       >
-        {options.map(option => (
-          <div
-            className={classNames('form-check', inline && 'form-check-inline')}
-            key={option.value}
-          >
-            <input
-              checked={contains(option.value, value)}
-              className={classNames('form-check-input', inputClassName)}
-              disabled={Boolean(option.disabled)}
-              style={inputStyle}
-              type="checkbox"
-              onChange={() => {
-                let newValue;
-                if (contains(option.value, value)) {
-                  newValue = without([option.value], value);
-                } else {
-                  newValue = append(option.value, value);
-                }
-                setProps({value: newValue});
-              }}
-            />
-            <label
-              style={labelStyle}
-              className={classNames('form-check-label', labelClassName)}
-              key={option.value}
-            >
-              {option.label}
-            </label>
-          </div>
-        ))}
+        {items}
       </div>
     );
   }
@@ -129,7 +198,7 @@ Checklist.propTypes = {
   key: PropTypes.string,
 
   /**
-   * The style of the <input> checkbox element
+   * The style of the <input> checkbox element. Only used if custom=False
    */
   inputStyle: PropTypes.object,
 
@@ -139,16 +208,26 @@ Checklist.propTypes = {
   inputClassName: PropTypes.string,
 
   /**
-   * The style of the <label> that wraps the checkbox input
-   *  and the option's label
+   * Inline style arguments to apply to the <label> element for each item.
    */
   labelStyle: PropTypes.object,
 
   /**
-   * The class of the <label> that wraps the checkbox input
-   *  and the option's label
+   * Additional inline style arguments to apply to <label> elements on checked
+   * items.
+   */
+  labelCheckedStyle: PropTypes.object,
+
+  /**
+   * CSS classes to apply to the <label> element for each item.
    */
   labelClassName: PropTypes.string,
+
+  /**
+   * Additional CSS classes to apply to the <label> element when the
+   * corresponding checkbox is checked.
+   */
+  labelCheckedClassName: PropTypes.string,
 
   /**
    * Dash-assigned callback that gets fired when the value changes.
@@ -159,6 +238,17 @@ Checklist.propTypes = {
    * Arrange Checklist inline
    */
   inline: PropTypes.bool,
+
+  /**
+   * Set to True to render toggle-like switches instead of checkboxes.
+   */
+  switch: PropTypes.bool,
+
+  /**
+   * RadioItems uses custom radio buttons by default. To use native radios set
+   * custom to False.
+   */
+  custom: PropTypes.bool,
 
   /**
    * Object that holds the loading state object coming from dash-renderer
@@ -185,7 +275,8 @@ Checklist.defaultProps = {
   labelStyle: {},
   labelClassName: '',
   options: [],
-  value: []
+  value: [],
+  custom: true
 };
 
 export default Checklist;

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -35,6 +35,7 @@ class RadioItems extends React.Component {
       key,
       value,
       custom,
+      switch: switches,
       loading_state
     } = this.props;
 
@@ -51,7 +52,7 @@ class RadioItems extends React.Component {
           checked={checked}
           className={inputClassName}
           disabled={Boolean(option.disabled)}
-          type="radio"
+          type={switches ? 'switch' : 'radio'}
           label={option.label}
           labelStyle={mergedLabelStyle}
           labelClassName={classNames(
@@ -223,6 +224,12 @@ RadioItems.propTypes = {
    * Arrange RadioItems inline
    */
   inline: PropTypes.bool,
+
+  /**
+   * Set to True to render toggle-like switches instead of radios. Ignored if
+   * custom=False
+   */
+  switch: PropTypes.bool,
 
   /**
    * RadioItems uses custom radio buttons by default. To use native radios set

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -1,16 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import CustomInput from '../../private/CustomInput';
 
 /**
  * RadioItems is a component that encapsulates several radio item inputs.
  * The values and labels of the RadioItems is specified in the `options`
  * property and the seleced item is specified with the `value` property.
- * Each radio item is rendered as an input with a surrounding label.
+ * Each radio item is rendered as an input and associated label which are
+ * siblings of each other.
  */
 
 class RadioItems extends React.Component {
-  render() {
+  constructor(props) {
+    super(props);
+
+    this.listItem = this.listItem.bind(this);
+  }
+
+  listItem(option) {
     const {
       id,
       className,
@@ -18,14 +26,91 @@ class RadioItems extends React.Component {
       inputClassName,
       inputStyle,
       labelClassName,
+      labelCheckedClassName,
       labelStyle,
+      labelCheckedStyle,
       options,
       setProps,
       inline,
       key,
       value,
+      custom,
       loading_state
     } = this.props;
+
+    const checked = option.value === value;
+
+    const mergedLabelStyle = checked
+      ? {...labelStyle, ...labelCheckedStyle}
+      : labelStyle;
+
+    if (id && custom) {
+      return (
+        <CustomInput
+          id={`${id}-${option.value}`}
+          checked={checked}
+          className={inputClassName}
+          disabled={Boolean(option.disabled)}
+          type="radio"
+          label={option.label}
+          labelStyle={mergedLabelStyle}
+          labelClassName={classNames(
+            labelClassName,
+            checked && labelCheckedClassName
+          )}
+          inline={inline}
+          onChange={() => {
+            setProps({value: option.value});
+          }}
+        />
+      );
+    } else {
+      return (
+        <div
+          className={classNames('form-check', inline && 'form-check-inline')}
+          key={option.value}
+        >
+          <input
+            checked={checked}
+            className={classNames('form-check-input', inputClassName)}
+            disabled={Boolean(option.disabled)}
+            style={inputStyle}
+            type="radio"
+            onChange={() => {
+              setProps({value: option.value});
+            }}
+          />
+          <label
+            style={mergedLabelStyle}
+            className={classNames(
+              'form-check-label',
+              labelClassName,
+              checked && labelCheckedClassName
+            )}
+            key={option.value}
+          >
+            {option.label}
+          </label>
+        </div>
+      );
+    }
+  }
+
+  render() {
+    const {
+      id,
+      className,
+      style,
+      options,
+      inline,
+      key,
+      loading_state,
+      custom
+    } = this.props;
+
+    const items = options.map(option => (
+      <React.Fragment>{this.listItem(option)}</React.Fragment>
+    ));
 
     return (
       <div
@@ -37,30 +122,7 @@ class RadioItems extends React.Component {
           (loading_state && loading_state.is_loading) || undefined
         }
       >
-        {options.map(option => (
-          <div
-            className={classNames('form-check', inline && 'form-check-inline')}
-            key={option.value}
-          >
-            <input
-              checked={option.value === value}
-              className={classNames('form-check-input', inputClassName)}
-              disabled={Boolean(option.disabled)}
-              style={inputStyle}
-              type="radio"
-              onChange={() => {
-                setProps({value: option.value});
-              }}
-            />
-            <label
-              style={labelStyle}
-              className={classNames('form-check-label', labelClassName)}
-              key={option.value}
-            >
-              {option.label}
-            </label>
-          </div>
-        ))}
+        {items}
       </div>
     );
   }
@@ -131,16 +193,26 @@ RadioItems.propTypes = {
   inputClassName: PropTypes.string,
 
   /**
-   * The style of the <label> that wraps the radio input
-   *  and the option's label
+   * Inline style arguments to apply to the <label> element for each item.
    */
   labelStyle: PropTypes.object,
 
   /**
-   * The class of the <label> that wraps the radio input
-   *  and the option's label
+   * Additional inline style arguments to apply to <label> elements on checked
+   * items.
+   */
+  labelCheckedStyle: PropTypes.object,
+
+  /**
+   * CSS classes to apply to the <label> element for each item.
    */
   labelClassName: PropTypes.string,
+
+  /**
+   * Additional CSS classes to apply to the <label> element when the
+   * corresponding radio is checked.
+   */
+  labelCheckedClassName: PropTypes.string,
 
   /**
    * Dash-assigned callback that gets fired when the value changes.
@@ -151,6 +223,12 @@ RadioItems.propTypes = {
    * Arrange RadioItems inline
    */
   inline: PropTypes.bool,
+
+  /**
+   * RadioItems uses custom radio buttons by default. To use native radios set
+   * custom to False.
+   */
+  custom: PropTypes.bool,
 
   /**
    * Object that holds the loading state object coming from dash-renderer
@@ -176,7 +254,8 @@ RadioItems.defaultProps = {
   inputClassName: '',
   labelStyle: {},
   labelClassName: '',
-  options: []
+  options: [],
+  custom: true
 };
 
 export default RadioItems;

--- a/src/private/CustomInput.js
+++ b/src/private/CustomInput.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const CustomInput = props => {
+  const {
+    className,
+    label,
+    inline,
+    valid,
+    invalid,
+    children,
+    bsSize,
+    innerRef,
+    htmlFor,
+    labelStyle,
+    labelClassName,
+    ...attributes
+  } = props;
+
+  const type = attributes.type;
+
+  const customClass = classNames(
+    className,
+    `custom-${type}`,
+    bsSize ? `custom-${type}-${bsSize}` : false
+  );
+
+  const validationClassNames = classNames(
+    invalid && 'is-invalid',
+    valid && 'is-valid'
+  );
+
+  const labelHtmlFor = htmlFor || attributes.id;
+
+  if (type === 'file') {
+    return (
+      <div className={customClass}>
+        <input
+          {...attributes}
+          ref={innerRef}
+          className={classNames(validationClassNames, 'custom-file-input')}
+        />
+        <label className="custom-file-label" htmlFor={labelHtmlFor}>
+          {label || 'Choose file'}
+        </label>
+      </div>
+    );
+  }
+
+  if (type !== 'checkbox' && type !== 'radio' && type !== 'switch') {
+    return (
+      <input {...attributes} ref={innerRef} className={validationClassNames} />
+    );
+  }
+
+  const wrapperClasses = classNames(
+    customClass,
+    classNames('custom-control', {'custom-control-inline': inline})
+  );
+
+  return (
+    <div className={wrapperClasses}>
+      <input
+        {...attributes}
+        type={type === 'switch' ? 'checkbox' : type}
+        ref={innerRef}
+        className={classNames(validationClassNames, 'custom-control-input')}
+      />
+      <label
+        className={classNames('custom-control-label', labelClassName)}
+        style={labelStyle}
+        htmlFor={labelHtmlFor}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+};
+
+CustomInput.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  type: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  inline: PropTypes.bool,
+  valid: PropTypes.bool,
+  invalid: PropTypes.bool,
+  bsSize: PropTypes.string,
+  htmlFor: PropTypes.string,
+  cssModule: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.array,
+    PropTypes.func
+  ]),
+  innerRef: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+    PropTypes.func
+  ]),
+  labelStyle: PropTypes.object,
+  labelClassName: PropTypes.string
+};
+
+export default CustomInput;


### PR DESCRIPTION
This PR makes a number of improvements to `RadioItems` and `Checklist`, primarily by allowing you to render radio buttons and checkboxes using [Bootstrap's custom styles](https://getbootstrap.com/docs/4.3/components/forms/#checkboxes-and-radios-1) rather than the native browser controls (native controls can still be used by setting `custom=False`). Here's a screenshot:

![image](https://user-images.githubusercontent.com/15220906/61531501-e2a95600-aa1e-11e9-9bd3-2f7c2bd7d35d.png)

I have also added `labelCheckedStyle` and `labelCheckedClassName` arguments that allow you to modify the style of labels corresponding to checked items.

All of this is documented in the refreshed documentation for inputs.

This PR addresses #184. 