### PR TITLE
Install dash[dev] rather than dash in CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - "node_modules"
 install:
-  - "if [[ \"$GROUP\" == js ]] ; then pip install dash ; fi"
+  - "if [[ \"$GROUP\" == js ]] ; then pip install dash[dev] ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm -v ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm install ; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then pip install black flake8 isort>=4.3.5 ; fi"


### PR DESCRIPTION
Some of Dash's dependencies for building components have been removed from the standard requirements and have been split out into dev requirements installed by running

```
pip install dash[dev]
```

This was causing CI checks to fail, which this small PR addresses.