### PR TITLE
Alert and Toast timeout

### DIFF
--- a/docs/components_page/components/alert/__init__.py
+++ b/docs/components_page/components/alert/__init__.py
@@ -20,6 +20,7 @@ alerts_simple_source = (HERE / "simple.py").read_text()
 alerts_link_source = (HERE / "link.py").read_text()
 alert_content_source = (HERE / "content.py").read_text()
 alerts_dismiss_source = (HERE / "dismiss.py").read_text()
+alerts_auto_dismiss_source = (HERE / "auto_dismiss.py").read_text()
 
 
 def get_content(app):
@@ -75,5 +76,20 @@ def get_content(app):
             )
         ),
         HighlightedSource(alerts_dismiss_source),
+        html.H4("Automatic dismissal"),
+        html.P(
+            dcc.Markdown(
+                "You can have your `Alert` components dismiss themselves by "
+                "using the `duration` keyword argument. Specify a duration in "
+                "milliseconds after which you would like the `Alert` to "
+                "dismiss itself when it first becomes visible."
+            )
+        ),
+        ExampleContainer(
+            load_source_with_environment(
+                alerts_auto_dismiss_source, "alert", {"app": app}
+            )
+        ),
+        HighlightedSource(alerts_auto_dismiss_source),
         ApiDoc(get_component_metadata("src/components/Alert.js")),
     ]

--- a/docs/components_page/components/alert/auto_dismiss.py
+++ b/docs/components_page/components/alert/auto_dismiss.py
@@ -1,0 +1,27 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+
+alert = html.Div(
+    [
+        dbc.Button("Toggle", id="alert-toggle-auto", className="mr-1"),
+        html.Hr(),
+        dbc.Alert(
+            "Hello! I am an auto-dismissing alert!",
+            id="alert-auto",
+            is_open=True,
+            duration=4000,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("alert-auto", "is_open"),
+    [Input("alert-toggle-auto", "n_clicks")],
+    [State("alert-auto", "is_open")],
+)
+def toggle_alert(n, is_open):
+    if n:
+        return not is_open
+    return is_open

--- a/docs/components_page/components/toast/__init__.py
+++ b/docs/components_page/components/toast/__init__.py
@@ -16,6 +16,7 @@ HERE = Path(__file__).parent
 
 toast_simple_source = (HERE / "simple.py").read_text()
 toast_icon_dismiss_source = (HERE / "icon_dismiss.py").read_text()
+toast_auto_dismiss_source = (HERE / "auto_dismiss.py").read_text()
 toast_position_source = (HERE / "position.py").read_text()
 
 
@@ -61,6 +62,21 @@ def get_content(app):
             )
         ),
         HighlightedSource(toast_icon_dismiss_source),
+        html.H4("Automatic dismissal"),
+        html.P(
+            dcc.Markdown(
+                "You can have your `Toast` components dismiss themselves by "
+                "using the `duration` keyword argument. Specify a duration in "
+                "milliseconds after which you would like the `Toast` to "
+                "dismiss itself when it first becomes visible."
+            )
+        ),
+        ExampleContainer(
+            load_source_with_environment(
+                toast_auto_dismiss_source, "toast", {"app": app}
+            )
+        ),
+        HighlightedSource(toast_auto_dismiss_source),
         html.H4("Positioning"),
         html.P(
             dcc.Markdown(

--- a/docs/components_page/components/toast/auto_dismiss.py
+++ b/docs/components_page/components/toast/auto_dismiss.py
@@ -1,0 +1,28 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+
+toast = html.Div(
+    [
+        dbc.Button(
+            "Open toast",
+            id="auto-toast-toggle",
+            color="primary",
+            className="mb-3",
+        ),
+        dbc.Toast(
+            [html.P("This is the content of the toast", className="mb-0")],
+            id="auto-toast",
+            header="This is the header",
+            icon="primary",
+            duration=4000,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("auto-toast", "is_open"), [Input("auto-toast-toggle", "n_clicks")]
+)
+def open_toast(n):
+    return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 exclude =
     node_modules,
     dash_bootstrap_components/_components,
+    docs/components_page/components/alert/auto_dismiss.py,
     docs/components_page/components/alert/dismiss.py,
     docs/components_page/components/button/usage.py,
     docs/components_page/components/collapse/accordion.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ exclude =
     docs/components_page/components/table/kwargs.py,
     docs/components_page/components/tabs/active_tab.py,
     docs/components_page/components/tabs/card.py,
+    docs/components_page/components/toast/auto_dismiss.py,
     docs/components_page/components/toast/icon_dismiss.py,
     docs/components_page/components/toast/position.py,
 ignore = E203, W503

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -6,14 +6,14 @@ class Alert extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onDismiss = this.onDismiss.bind(this);
+    this.dismiss = this.dismiss.bind(this);
 
     this.state = {
       alertOpen: props.is_open
     };
   }
 
-  onDismiss() {
+  dismiss() {
     if (this.props.setProps) {
       this.props.setProps({is_open: false});
     } else {
@@ -24,6 +24,15 @@ class Alert extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.is_open != this.state.alertOpen) {
       this.setState({alertOpen: nextProps.is_open});
+      if (nextProps.is_open && this.props.duration) {
+        setTimeout(this.dismiss, this.props.duration);
+      }
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.is_open && this.props.duration) {
+      setTimeout(this.dismiss, this.props.duration);
     }
   }
 
@@ -38,7 +47,7 @@ class Alert extends React.Component {
     return (
       <RSAlert
         isOpen={this.state.alertOpen}
-        toggle={dismissable && this.onDismiss}
+        toggle={dismissable && this.dismiss}
         {...otherProps}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
@@ -51,7 +60,8 @@ class Alert extends React.Component {
 }
 
 Alert.defaultProps = {
-  is_open: true
+  is_open: true,
+  duration: null
 };
 
 Alert.propTypes = {
@@ -105,6 +115,11 @@ Alert.propTypes = {
    * If true, add a close button that allows Alert to be dismissed.
    */
   dismissable: PropTypes.bool,
+
+  /**
+   * Duration in milliseconds after which the Alert dismisses itself.
+   */
+  duration: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,33 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Toast, ToastBody, ToastHeader} from 'reactstrap';
+import {Toast as RSToast, ToastBody, ToastHeader} from 'reactstrap';
 
-class ToastSimple extends React.Component {
+class Toast extends React.Component {
   constructor(props) {
     super(props);
 
-    this.toggle = this.toggle.bind(this);
+    this.dismiss = this.dismiss.bind(this);
     this.state = {
-      ToastOpen: props.is_open
+      toastOpen: props.is_open
     };
   }
 
-  toggle() {
+  dismiss() {
     if (this.props.setProps) {
       this.props.setProps({
-        is_open: !this.state.ToastOpen,
+        is_open: false,
         n_dismiss: this.props.n_dismiss + 1,
         n_dismiss_timestamp: Date.now()
       });
     } else {
-      this.setState({ToastOpen: !this.state.ToastOpen});
+      this.setState({toastOpen: false});
     }
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.is_open != prevState.ToastOpen) {
-      return {ToastOpen: nextProps.is_open};
-    } else return null;
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.is_open != this.state.toastOpen) {
+      this.setState({toastOpen: nextProps.is_open});
+      if (nextProps.is_open && this.props.duration) {
+        setTimeout(this.dismiss, this.props.duration);
+      }
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.is_open && this.props.duration) {
+      setTimeout(this.dismiss, this.props.duration);
+    }
   }
 
   render() {
@@ -43,28 +52,28 @@ class ToastSimple extends React.Component {
       ...otherProps
     } = this.props;
     return (
-      <Toast isOpen={this.state.ToastOpen} {...otherProps}>
+      <RSToast isOpen={this.state.toastOpen} {...otherProps}>
         <ToastHeader
           icon={icon}
           style={header_style}
           className={headerClassName}
-          toggle={dismissable && this.toggle}
+          toggle={dismissable && this.dismiss}
         >
           {header}
         </ToastHeader>
         <ToastBody style={body_style} className={bodyClassName}>
           {children}
         </ToastBody>
-      </Toast>
+      </RSToast>
     );
   }
 }
 
-ToastSimple.defaultProps = {
+Toast.defaultProps = {
   is_open: true
 };
 
-ToastSimple.propTypes = {
+Toast.propTypes = {
   /**
    * The ID of this component, used to identify dash components
    * in callbacks. The ID needs to be unique across all of the
@@ -145,6 +154,11 @@ ToastSimple.propTypes = {
   dismissable: PropTypes.bool,
 
   /**
+   * Duration in milliseconds after which the Alert dismisses itself.
+   */
+  duration: PropTypes.number,
+
+  /**
    * An integer that represents the number of times that the dismiss button has
    * been clicked on.
    */
@@ -167,4 +181,4 @@ ToastSimple.propTypes = {
   icon: PropTypes.string
 };
 
-export default ToastSimple;
+export default Toast;


### PR DESCRIPTION
This PR addresses #190, adding a `duration` prop to both `Alert` and `Toast` allowing user to specify a timeout in milliseconds after which the alert or toast is dismissed.