### PR TITLE
Add href prop to Button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,19 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Button as RSButton} from 'reactstrap';
+import Link from '../private/Link';
 
 const Button = props => {
-  const {children, loading_state, setProps, ...otherProps} = props;
+  const {
+    children,
+    href,
+    loading_state,
+    setProps,
+    n_clicks,
+    ...otherProps
+  } = props;
+
+  const incrementClicks = () => {
+    if (!props.disabled && setProps) {
+      setProps({
+        n_clicks: n_clicks + 1,
+        n_clicks_timestamp: Date.now()
+      });
+    }
+  };
+  const useLink = href && !props.disabled;
+  otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
+
   return (
     <RSButton
-      onClick={() => {
-        if (setProps) {
-          setProps({
-            n_clicks: props.n_clicks + 1,
-            n_clicks_timestamp: Date.now()
-          });
-        }
-      }}
+      tag={useLink ? Link : 'button'}
+      href={props.disabled ? null : href}
       {...otherProps}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
@@ -58,6 +72,21 @@ Button.propTypes = {
    * See https://reactjs.org/docs/lists-and-keys.html for more info
    */
   key: PropTypes.string,
+
+  /**
+   * Pass a URL (relative or absolute) to make the menu entry a link.
+   */
+  href: PropTypes.string,
+
+  /**
+   * If true, the browser will treat this as an external link,
+   * forcing a page refresh at the new location. If false,
+   * this just changes the location without triggering a page
+   * refresh. Use this if you are observing dcc.Location, for
+   * instance. Defaults to true for absolute URLs and false
+   * otherwise.
+   */
+  external_link: PropTypes.bool,
 
   /**
    * An integer that represents the number of times


### PR DESCRIPTION
This PR adds a `href` prop to `Button` to allow links to be attached to buttons without having to wrap them with a `html.A` or `dcc.Link` element, this being important for preserving correct styling when using `InputGroup` or `ButtonGroup` as noted in #258.