### PR TITLE
Prevent setProps being passed to DOM elements

### DIFF
--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Alert as RSAlert} from 'reactstrap';
 
 class Alert extends React.Component {
@@ -48,7 +49,7 @@ class Alert extends React.Component {
       <RSAlert
         isOpen={this.state.alertOpen}
         toggle={dismissable && this.dismiss}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Badge as RSBadge} from 'reactstrap';
 
 const Badge = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSBadge
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import {Button as RSButton} from 'reactstrap';
 
 const Button = props => {
-  const {children, loading_state, ...otherProps} = props;
+  const {children, loading_state, setProps, ...otherProps} = props;
   return (
     <RSButton
       onClick={() => {
-        if (props.setProps) {
-          props.setProps({
+        if (setProps) {
+          setProps({
             n_clicks: props.n_clicks + 1,
             n_clicks_timestamp: Date.now()
           });

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ButtonGroup as RSButtonGroup} from 'reactstrap';
 
 const ButtonGroup = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSButtonGroup
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Collapse as RSCollapse} from 'reactstrap';
 
 const Collapse = props => {
@@ -7,7 +8,7 @@ const Collapse = props => {
   return (
     <RSCollapse
       isOpen={is_open}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Dropdown, DropdownToggle} from 'reactstrap';
 import {DropdownMenu as RSDropdownMenu} from 'reactstrap';
 
@@ -47,7 +48,7 @@ class DropdownMenu extends React.Component {
         inNavbar={in_navbar}
         addonType={addon_type}
         size={bs_size}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/DropdownMenuItem.js
+++ b/src/components/DropdownMenuItem.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {DropdownItem as RSDropdownItem} from 'reactstrap';
 import Link from '../private/Link';
-import Button from './Button';
 
 class DropdownMenuItem extends React.Component {
   constructor(props) {
@@ -30,7 +30,7 @@ class DropdownMenuItem extends React.Component {
         // don't pass href if disabled otherwise reactstrap renders item
         // as link and the cursor becomes a pointer on hover
         href={this.props.disabled ? null : href}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/Fade.js
+++ b/src/components/Fade.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Fade as RSFade} from 'reactstrap';
 
 const Fade = props => {
@@ -16,7 +17,7 @@ const Fade = props => {
       baseClass={base_class}
       baseClassActive={base_class_active}
       in={is_in}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Jumbotron.js
+++ b/src/components/Jumbotron.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Jumbotron as RSJumbotron} from 'reactstrap';
 
 const Jumbotron = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSJumbotron
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Label as RSLabel} from 'reactstrap';
 import classNames from 'classnames';
 
@@ -41,7 +42,7 @@ const Label = props => {
       for={html_for}
       xs={xs || width}
       className={classes}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Popover as RSPopover} from 'reactstrap';
 
 const Popover = props => {
@@ -8,7 +9,7 @@ const Popover = props => {
     <RSPopover
       isOpen={is_open}
       hideArrow={hide_arrow}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/PopoverBody.js
+++ b/src/components/PopoverBody.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {PopoverBody as RSPopoverBody} from 'reactstrap';
 
 const PopoverBody = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSPopoverBody
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/PopoverHeader.js
+++ b/src/components/PopoverHeader.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {PopoverHeader as RSPopoverHeader} from 'reactstrap';
 
 const PopoverHeader = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSPopoverHeader
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Progress as RSProgress} from 'reactstrap';
 
 const Progress = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSProgress
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Spinner as RSSpinner} from 'reactstrap';
 
 const Spinner = props => {
   const {children, ...otherProps} = props;
-  return <RSSpinner {...otherProps}>{children}</RSSpinner>;
+  return <RSSpinner {...omit(['setProps'], otherProps)}>{children}</RSSpinner>;
 };
 
 Spinner.propTypes = {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Table as RSTable} from 'reactstrap';
 
 const Table = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSTable
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Toast as RSToast, ToastBody, ToastHeader} from 'reactstrap';
 
 class Toast extends React.Component {
@@ -52,7 +53,10 @@ class Toast extends React.Component {
       ...otherProps
     } = this.props;
     return (
-      <RSToast isOpen={this.state.toastOpen} {...otherProps}>
+      <RSToast
+        isOpen={this.state.toastOpen}
+        {...omit(['setProps'], otherProps)}
+      >
         <ToastHeader
           icon={icon}
           style={header_style}

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Tooltip as RSTooltip} from 'reactstrap';
 
 class Tooltip extends React.Component {
@@ -33,7 +34,7 @@ class Tooltip extends React.Component {
         isOpen={this.state.tooltipOpen}
         hideArrow={hide_arrow}
         boundariesElement={boundaries_element}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Card as RSCard} from 'reactstrap';
 
 const Card = props => {
@@ -9,7 +10,7 @@ const Card = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCard>

--- a/src/components/card/CardBody.js
+++ b/src/components/card/CardBody.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardBody as RSCardBody} from 'reactstrap';
 
 const CardBody = props => {
@@ -9,7 +10,7 @@ const CardBody = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardBody>

--- a/src/components/card/CardColumns.js
+++ b/src/components/card/CardColumns.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardColumns as RSCardColumns} from 'reactstrap';
 
 const CardColumns = props => {
@@ -9,7 +10,7 @@ const CardColumns = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardColumns>

--- a/src/components/card/CardDeck.js
+++ b/src/components/card/CardDeck.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardDeck as RSCardDeck} from 'reactstrap';
 
 const CardDeck = props => {
@@ -9,7 +10,7 @@ const CardDeck = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardDeck>

--- a/src/components/card/CardFooter.js
+++ b/src/components/card/CardFooter.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardFooter as RSCardFooter} from 'reactstrap';
 
 const CardFooter = props => {
@@ -9,7 +10,7 @@ const CardFooter = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardFooter>

--- a/src/components/card/CardGroup.js
+++ b/src/components/card/CardGroup.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardGroup as RSCardGroup} from 'reactstrap';
 
 const CardGroup = props => {
@@ -9,7 +10,7 @@ const CardGroup = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardGroup>

--- a/src/components/card/CardHeader.js
+++ b/src/components/card/CardHeader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardHeader as RSCardHeader} from 'reactstrap';
 
 const CardHeader = props => {
@@ -9,7 +10,7 @@ const CardHeader = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardHeader>

--- a/src/components/card/CardImg.js
+++ b/src/components/card/CardImg.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardImg as RSCardImg} from 'reactstrap';
 
 const CardImg = props => {
@@ -9,7 +10,7 @@ const CardImg = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardImg>

--- a/src/components/card/CardImgOverlay.js
+++ b/src/components/card/CardImgOverlay.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {CardImgOverlay as RSCardImgOverlay} from 'reactstrap';
 
 const CardImgOverlay = props => {
@@ -9,7 +10,7 @@ const CardImgOverlay = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardImgOverlay>

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import classNames from 'classnames';
 import {CardLink as RSCardLink} from 'reactstrap';
 import Link from '../../private/Link';
@@ -12,7 +13,7 @@ const CardLink = props => {
         (loading_state && loading_state.is_loading) || undefined
       }
       tag={Link}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
     >
       {children}
     </RSCardLink>

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Form as RSForm} from 'reactstrap';
 
 const Form = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSForm
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/form/FormFeedback.js
+++ b/src/components/form/FormFeedback.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {FormFeedback as RSFormFeedback} from 'reactstrap';
 
 const FormFeedback = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSFormFeedback
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/form/FormGroup.js
+++ b/src/components/form/FormGroup.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {FormGroup as RSFormGroup} from 'reactstrap';
 
 const FormGroup = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSFormGroup
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/form/FormText.js
+++ b/src/components/form/FormText.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {FormText as RSFormText} from 'reactstrap';
 
 const FormText = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSFormText
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {InputGroup as RSInputGroup} from 'reactstrap';
 
 const InputGroup = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSInputGroup
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/input/InputGroupAddon.js
+++ b/src/components/input/InputGroupAddon.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import classNames from 'classnames';
 import InputGroupText from './InputGroupText';
 
@@ -11,7 +12,7 @@ const InputGroupAddon = props => {
     return (
       <div
         className={classes}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }
@@ -22,7 +23,7 @@ const InputGroupAddon = props => {
   }
 
   return (
-    <div className={classes} {...otherProps}>
+    <div className={classes} {...omit(['setProps'], otherProps)}>
       {children}
     </div>
   );

--- a/src/components/input/InputGroupText.js
+++ b/src/components/input/InputGroupText.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {InputGroupText as RSInputGroupText} from 'reactstrap';
 
 const InputGroupText = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSInputGroupText
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -21,22 +21,17 @@ class RadioItems extends React.Component {
   listItem(option) {
     const {
       id,
-      className,
-      style,
       inputClassName,
       inputStyle,
       labelClassName,
       labelCheckedClassName,
       labelStyle,
       labelCheckedStyle,
-      options,
       setProps,
       inline,
-      key,
       value,
       custom,
       switch: switches,
-      loading_state
     } = this.props;
 
     const checked = option.value === value;
@@ -103,10 +98,8 @@ class RadioItems extends React.Component {
       className,
       style,
       options,
-      inline,
       key,
       loading_state,
-      custom
     } = this.props;
 
     const items = options.map(option => (

--- a/src/components/layout/Col.js
+++ b/src/components/layout/Col.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Col as RSCol} from 'reactstrap';
 import classNames from 'classnames';
 
@@ -29,7 +30,7 @@ const Col = props => {
     <RSCol
       xs={xs || width}
       className={classes}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/layout/Row.js
+++ b/src/components/layout/Row.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Row as RSRow} from 'reactstrap';
 import classNames from 'classnames';
 
@@ -38,7 +39,7 @@ const Row = props => {
     <RSRow
       className={classes}
       noGutters={no_gutters}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/listgroup/ListGroup.js
+++ b/src/components/listgroup/ListGroup.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ListGroup as RSListGroup} from 'reactstrap';
 
 const ListGroup = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSListGroup
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ListGroupItem as RSListGroupItem} from 'reactstrap';
 import Link from '../../private/Link';
 
@@ -26,7 +27,7 @@ class ListGroupItem extends React.Component {
     return (
       <RSListGroupItem
         tag={useLink ? Link : 'li'}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/listgroup/ListGroupItemHeading.js
+++ b/src/components/listgroup/ListGroupItemHeading.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ListGroupItemHeading as RSListGroupItemHeading} from 'reactstrap';
 
 const ListGroupItemHeading = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSListGroupItemHeading
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/listgroup/ListGroupItemText.js
+++ b/src/components/listgroup/ListGroupItemText.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ListGroupItemText as RSListGroupItemText} from 'reactstrap';
 import classNames from 'classnames';
 
@@ -9,7 +10,7 @@ const ListGroupItemText = props => {
   return (
     <RSListGroupItemText
       className={classes}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Modal as RSModal} from 'reactstrap';
 
 class Modal extends React.Component {
@@ -32,7 +33,7 @@ class Modal extends React.Component {
       <RSModal
         isOpen={this.state.modalOpen}
         toggle={this.toggle}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
       >
         {children}
       </RSModal>

--- a/src/components/modal/ModalBody.js
+++ b/src/components/modal/ModalBody.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ModalBody as RSModalBody} from 'reactstrap';
 
 const ModalBody = props => {
   const {children, ...otherProps} = props;
-  return <RSModalBody {...otherProps}>{children}</RSModalBody>;
+  return (
+    <RSModalBody {...omit(['setProps'], otherProps)}>{children}</RSModalBody>
+  );
 };
 
 ModalBody.propTypes = {

--- a/src/components/modal/ModalFooter.js
+++ b/src/components/modal/ModalFooter.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ModalFooter as RSModalFooter} from 'reactstrap';
 
 const ModalFooter = props => {
   const {children, ...otherProps} = props;
-  return <RSModalFooter {...otherProps}>{children}</RSModalFooter>;
+  return <RSModalFooter {...omit(['setProps'], otherProps)}>{children}</RSModalFooter>;
 };
 
 ModalFooter.propTypes = {

--- a/src/components/modal/ModalHeader.js
+++ b/src/components/modal/ModalHeader.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {ModalHeader as RSModalHeader} from 'reactstrap';
 
 const ModalHeader = props => {
   const {children, ...otherProps} = props;
-  return <RSModalHeader {...otherProps}>{children}</RSModalHeader>;
+  return <RSModalHeader {...omit(['setProps'], otherProps)}>{children}</RSModalHeader>;
 };
 
 ModalHeader.propTypes = {

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Nav as RSNav} from 'reactstrap';
 
 const Nav = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSNav
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/nav/NavItem.js
+++ b/src/components/nav/NavItem.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {NavItem as RSNavItem} from 'reactstrap';
 
 const NavItem = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSNavItem
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import classNames from 'classnames';
 import Link from '../../private/Link';
 
@@ -35,7 +36,7 @@ class NavLink extends React.Component {
       <Link
         className={classes}
         preOnClick={this.incrementClicks}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Navbar as RSNavbar} from 'reactstrap';
 
 const navbarColors = new Set([
@@ -22,7 +23,7 @@ const Navbar = props => {
     <RSNavbar
       color={isNavbarColor && color}
       style={{backgroundColor: !isNavbarColor && color, ...style}}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/nav/NavbarBrand.js
+++ b/src/components/nav/NavbarBrand.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {NavbarBrand as RSNavbarBrand} from 'reactstrap';
 import Link from '../../private/Link';
 
@@ -7,7 +8,7 @@ const NavbarBrand = props => {
   const {children, loading_state, ...otherProps} = props;
   return (
     <RSNavbarBrand
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       tag={props.href ? Link : 'span'}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined

--- a/src/components/nav/NavbarSimple.js
+++ b/src/components/nav/NavbarSimple.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Collapse, Container, Navbar as RSNavbar} from 'reactstrap';
-
-import Link from '../../private/Link';
 
 import Nav from './Nav';
 import NavbarBrand from './NavbarBrand';
@@ -55,7 +54,7 @@ class NavbarSimple extends React.Component {
       <RSNavbar
         color={isNavbarColor && color}
         style={{backgroundColor: !isNavbarColor && color, ...style}}
-        {...otherProps}
+        {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {NavbarToggler as RSNavbarToggler} from 'reactstrap';
 
 const NavbarToggler = props => {
@@ -14,7 +15,7 @@ const NavbarToggler = props => {
           });
         }
       }}
-      {...otherProps}
+      {...omit(['setProps'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import classnames from 'classnames';
 import {Nav, NavItem, NavLink, TabContent, TabPane} from 'reactstrap';
 import {isNil} from 'ramda';
@@ -127,7 +128,7 @@ class Tabs extends React.Component {
         <TabPane
           tabId={tabId}
           key={tabId}
-          {...otherProps}
+          {...omit(['setProps'], otherProps)}
           data-dash-is-loading={
             (loading_state && loading_state.is_loading) || undefined
           }


### PR DESCRIPTION
This PR ensures that `setProps` is not passed on to DOM elements by our components, which was causing error messages to appear in the console. I used `omit` from `ramda` since we were already using it to do this in the implementation of `Input`.