### PR TITLE
Set key on Checklist and RadioItems items

### DIFF
--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -19,7 +19,6 @@ class Checklist extends React.Component {
 
   listItem(option) {
     const {
-      className,
       id,
       inputClassName,
       inputStyle,
@@ -27,13 +26,9 @@ class Checklist extends React.Component {
       labelCheckedClassName,
       labelStyle,
       labelCheckedStyle,
-      options,
       setProps,
-      style,
       inline,
-      key,
       value,
-      loading_state,
       custom,
       switch: switches
     } = this.props;
@@ -68,6 +63,7 @@ class Checklist extends React.Component {
             }
             setProps({value: newValue});
           }}
+          key={option.value}
         />
       );
     } else {
@@ -109,21 +105,9 @@ class Checklist extends React.Component {
   }
 
   render() {
-    const {
-      className,
-      id,
-      options,
-      style,
-      inline,
-      key,
-      loading_state,
-      custom,
-      switch: switches
-    } = this.props;
+    const {className, id, options, style, key, loading_state} = this.props;
 
-    const items = options.map(option => (
-      <React.Fragment>{this.listItem(option)}</React.Fragment>
-    ));
+    const items = options.map(option => this.listItem(option));
 
     return (
       <div

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -31,7 +31,7 @@ class RadioItems extends React.Component {
       inline,
       value,
       custom,
-      switch: switches,
+      switch: switches
     } = this.props;
 
     const checked = option.value === value;
@@ -58,6 +58,7 @@ class RadioItems extends React.Component {
           onChange={() => {
             setProps({value: option.value});
           }}
+          key={option.value}
         />
       );
     } else {
@@ -93,18 +94,9 @@ class RadioItems extends React.Component {
   }
 
   render() {
-    const {
-      id,
-      className,
-      style,
-      options,
-      key,
-      loading_state,
-    } = this.props;
+    const {id, className, style, options, key, loading_state} = this.props;
 
-    const items = options.map(option => (
-      <React.Fragment>{this.listItem(option)}</React.Fragment>
-    ));
+    const items = options.map(option => this.listItem(option));
 
     return (
       <div


### PR DESCRIPTION
Previously `Checklist` and `RadioItems` were not correctly supplying a key to each of the items causing React to spit out warnings into the browser console. This PR fixes that, and tidies up some unused variables in the source code.