### PR TITLE
Allow Select value to be set in callback

### DIFF
--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -1,17 +1,24 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {CustomInput} from 'reactstrap';
 
 const Select = props => {
-  const [value, setValue] = useState(props.value);
+  const [value, setValue] = useState('');
 
   const handleChange = e => {
     if (props.setProps) {
       props.setProps({value: e.target.value});
+    } else {
+      setValue(e.target.value);
     }
-    setValue(e.target.value);
   };
+
+  useEffect(() => {
+    if (props.value !== value) {
+      setValue(props.value || '');
+    }
+  }, [props.value]);
 
   return (
     <CustomInput
@@ -21,6 +28,7 @@ const Select = props => {
       value={value}
       bsSize={props.bs_size}
     >
+      <option value="" disabled hidden></option>
       {props.options.map(option => (
         <option
           key={option.value}


### PR DESCRIPTION
This PR addresses #267, allowing the value of the `Select` component to be set by a callback. Previously the only way to change the value was to interact with it in the UI, so the value could only be used as an `Input` to callbacks, not an `Output`.

The changes can be tested with the following prerelease

```
pip install dash-bootstrap-components==0.7.2rc3
```