### PR TITLE
Reformat with new version of Black

### DIFF
--- a/docs/components_page/components/collapse/__init__.py
+++ b/docs/components_page/components/collapse/__init__.py
@@ -11,9 +11,7 @@ from ...helpers import (
 )
 from ...metadata import get_component_metadata
 
-ACCORDION = (
-    "https://getbootstrap.com/docs/4.3/components/collapse/#accordion-example"
-)  # noqa
+ACCORDION = "https://getbootstrap.com/docs/4.3/components/collapse/#accordion-example"  # noqa
 
 HERE = Path(__file__).parent
 


### PR DESCRIPTION
An update to black meant that the CI tests were failing, this fixes that.