### PR TITLE
Support persistence for non-boolean props

### DIFF
--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -251,7 +251,36 @@ Checklist.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 Checklist.defaultProps = {
@@ -261,7 +290,9 @@ Checklist.defaultProps = {
   labelClassName: '',
   options: [],
   value: [],
-  custom: true
+  custom: true,
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 export default Checklist;

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -88,7 +88,10 @@ class Input extends React.Component {
             'invalid',
             'bs_size',
             'plaintext',
-            'loading_state'
+            'loading_state',
+            'persistence',
+            'persistence_type',
+            'persisted_props'
           ],
           this.props
         )}
@@ -425,7 +428,36 @@ Input.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 Input.defaultProps = {
@@ -433,7 +465,9 @@ Input.defaultProps = {
   n_blur_timestamp: -1,
   n_submit: 0,
   n_submit_timestamp: -1,
-  debounce: false
+  debounce: false,
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 export default Input;

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -238,7 +238,36 @@ RadioItems.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 RadioItems.defaultProps = {
@@ -247,7 +276,9 @@ RadioItems.defaultProps = {
   labelStyle: {},
   labelClassName: '',
   options: [],
-  custom: true
+  custom: true,
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 export default RadioItems;

--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -22,7 +22,18 @@ const Select = props => {
 
   return (
     <CustomInput
-      {...omit(['value', 'setProps', 'bs_size', 'options'], props)}
+      {...omit(
+        [
+          'value',
+          'setProps',
+          'bs_size',
+          'options',
+          'persistence',
+          'persistence_type',
+          'persisted_props'
+        ],
+        props
+      )}
       type="select"
       onChange={handleChange}
       value={value}
@@ -40,6 +51,11 @@ const Select = props => {
       ))}
     </CustomInput>
   );
+};
+
+Select.defaultProps = {
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 Select.propTypes = {
@@ -117,7 +133,36 @@ Select.propTypes = {
    * Set the size of the Input. Options: 'sm' (small), 'md' (medium)
    * or 'lg' (large). Default is 'md'.
    */
-  bs_size: PropTypes.string
+  bs_size: PropTypes.string,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Select;

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -83,7 +83,10 @@ class Textarea extends React.Component {
             'n_submit',
             'n_submit_timestamp',
             'debounce',
-            'loading_state'
+            'loading_state',
+            'persistence',
+            'persistence_type',
+            'persisted_props'
           ],
           this.props
         )}
@@ -301,7 +304,36 @@ Textarea.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 Textarea.defaultProps = {
@@ -309,7 +341,9 @@ Textarea.defaultProps = {
   n_blur_timestamp: -1,
   n_clicks: 0,
   n_clicks_timestamp: -1,
-  debounce: false
+  debounce: false,
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 export default Textarea;

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -133,7 +133,15 @@ class Tabs extends React.Component {
           <TabPane
             tabId={tabId}
             key={tabId}
-            {...omit(['setProps'], otherProps)}
+            {...omit(
+              [
+                'setProps',
+                'persistence',
+                'persistence_type',
+                'persisted_props'
+              ],
+              otherProps
+            )}
             data-dash-is-loading={
               (loading_state && loading_state.is_loading) || undefined
             }
@@ -164,6 +172,10 @@ class Tabs extends React.Component {
     );
   }
 }
+
+Tabs.defaultProps = {
+  persisted_props: ['active_tab'],
+  persistence_type: 'local'}
 
 Tabs.propTypes = {
   /**
@@ -223,7 +235,36 @@ Tabs.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['active_tab'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Tabs;


### PR DESCRIPTION
This PR adds preliminary support for persistence for non-boolean props. Support for boolean props will be added when [this issue](https://github.com/plotly/dash/issues/1034) is resolved.