### PR TITLE
Add target prop to link components

### DIFF
--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -4,7 +4,14 @@ import {Badge as RSBadge} from 'reactstrap';
 import Link from '../private/Link';
 
 const Badge = props => {
-  const {children, href, loading_state, setProps, ...otherProps} = props;
+  const {
+    children,
+    href,
+    loading_state,
+    setProps,
+    target,
+    ...otherProps
+  } = props;
 
   const incrementClicks = () => {
     if (setProps) {
@@ -126,7 +133,12 @@ Badge.propTypes = {
    * at which n_clicks changed. This can be used to tell
    * which button was changed most recently.
    */
-  n_clicks_timestamp: PropTypes.number
+  n_clicks_timestamp: PropTypes.number,
+
+  /**
+   * Target attribute to pass on to the link. Only applies to external links.
+   */
+  target: PropTypes.string
 };
 
 export default Badge;

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -28,6 +28,7 @@ const Badge = props => {
     <RSBadge
       tag={href && Link}
       href={href}
+      target={href && target}
       {...otherProps}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -10,6 +10,7 @@ const Button = props => {
     loading_state,
     setProps,
     n_clicks,
+    target,
     ...otherProps
   } = props;
 
@@ -27,6 +28,7 @@ const Button = props => {
   return (
     <RSButton
       tag={useLink ? Link : 'button'}
+      target={useLink && target}
       href={props.disabled ? null : href}
       {...otherProps}
       data-dash-is-loading={
@@ -160,7 +162,12 @@ Button.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Target attribute to pass on to link if using Button as an external link.
+   */
+  target: PropTypes.string
 };
 
 export default Button;

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
-import classNames from 'classnames';
 import {CardLink as RSCardLink} from 'reactstrap';
 import Link from '../../private/Link';
 
@@ -94,7 +93,12 @@ CardLink.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Target attribute to pass on to the link. Only applies to external links.
+   */
+  target: PropTypes.string
 };
 
 export default CardLink;

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -29,7 +29,7 @@ class DropdownMenuItem extends React.Component {
   }
 
   render() {
-    let {children, href, loading_state, ...otherProps} = this.props;
+    let {children, href, loading_state, target, ...otherProps} = this.props;
     const useLink = href && !this.props.disabled;
     otherProps[useLink ? 'preOnClick' : 'onClick'] = e => this.handleClick(e);
     return (
@@ -38,6 +38,7 @@ class DropdownMenuItem extends React.Component {
         // don't pass href if disabled otherwise reactstrap renders item
         // as link and the cursor becomes a pointer on hover
         href={this.props.disabled ? null : href}
+        target={useLink && target}
         {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
@@ -150,7 +151,12 @@ DropdownMenuItem.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Target attribute to pass on to the link. Only applies to external links.
+   */
+  target: PropTypes.string
 };
 
 DropdownMenuItem.defaultProps = {

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -21,12 +21,13 @@ class ListGroupItem extends React.Component {
   }
 
   render() {
-    let {children, loading_state, ...otherProps} = this.props;
+    let {children, loading_state, target, ...otherProps} = this.props;
     const useLink = this.props.href && !this.props.disabled;
     otherProps[useLink ? 'preOnClick' : 'onClick'] = this.incrementClicks;
     return (
       <RSListGroupItem
         tag={useLink ? Link : 'li'}
+        target={useLink && target}
         {...omit(['setProps'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
@@ -138,7 +139,12 @@ ListGroupItem.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Target attribute to pass on to the link. Only applies to external links.
+   */
+  target: PropTypes.string
 };
 
 export default ListGroupItem;

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -138,7 +138,12 @@ NavLink.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Target attribute to pass on to the link. Only applies to external links.
+   */
+  target: PropTypes.string
 };
 
 export default NavLink;

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -131,7 +131,9 @@ Link.propTypes = {
   /**
    * Function to be executed on click before the redirect logic of Link.
    */
-  preOnClick: PropTypes.func
+  preOnClick: PropTypes.func,
+
+  target: PropTypes.string
 };
 
 Link.defaultProps = {

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -58,14 +58,26 @@ class Link extends Component {
   }
 
   render() {
-    const {children, external_link, preOnClick, ...otherProps} = this.props;
+    const {
+      children,
+      external_link,
+      preOnClick,
+      target,
+      href,
+      ...otherProps
+    } = this.props;
     /**
      * ideally, we would use cloneElement however
      * that doesn't work with dash's recursive
      * renderTree implementation for some reason
      */
     return (
-      <a {...otherProps} onClick={e => this.updateLocation(e)}>
+      <a
+        href={href}
+        target={isExternalLink(external_link, href) && target}
+        {...otherProps}
+        onClick={e => this.updateLocation(e)}
+      >
         {children}
       </a>
     );


### PR DESCRIPTION
This PR adds a `target` to components that can be used as links, resolving #304.