### PR TITLE
Update Link to use new Dash api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "Source": GITHUB_URL,
     },
     packages=find_packages(),
-    install_requires=["dash>=1.3.0"],
+    install_requires=["dash>=1.9.0"],
     include_package_data=True,
     classifiers=[
         "Framework :: Dash",

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -51,7 +51,7 @@ class Link extends Component {
       e.preventDefault();
       const {href} = this.props;
       window.history.pushState({}, '', href);
-      window.dispatchEvent(new CustomEvent('onpushstate'));
+      window.dispatchEvent(new CustomEvent('_dashprivate_pushstate'));
       // scroll back to top
       window.scrollTo(0, 0);
     }


### PR DESCRIPTION
The event name used to update `dcc.Location` [changed](https://github.com/plotly/dash-core-components/pull/743). This PR fixes that and bumps the version requirement of Dash to ensure compatibility.