### PR TITLE
Improve link components

### DIFF
--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -1,17 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 import {Badge as RSBadge} from 'reactstrap';
 import Link from '../private/Link';
 
 const Badge = props => {
-  const {
-    children,
-    href,
-    loading_state,
-    setProps,
-    target,
-    ...otherProps
-  } = props;
+  const {children, href, loading_state, setProps, ...otherProps} = props;
 
   const incrementClicks = () => {
     if (setProps) {
@@ -28,8 +22,7 @@ const Badge = props => {
     <RSBadge
       tag={href && Link}
       href={href}
-      target={href && target}
-      {...otherProps}
+      {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -28,7 +28,7 @@ const Button = props => {
   return (
     <RSButton
       tag={useLink ? Link : 'button'}
-      target={useLink && target}
+      target={useLink ? target : null}
       href={props.disabled ? null : href}
       {...otherProps}
       data-dash-is-loading={

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -6,18 +6,24 @@ import Link from '../../private/Link';
 
 const CardLink = props => {
   const {children, loading_state, ...otherProps} = props;
+
   return (
     <RSCardLink
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
       tag={Link}
-      {...omit(['setProps'], otherProps)}
+      {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
     >
       {children}
     </RSCardLink>
   );
 };
+
+CardLink.defaultProps = {
+    n_clicks: 0,
+    n_clicks_timestamp: -1
+}
 
 CardLink.propTypes = {
   /**

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -28,7 +28,7 @@ class ListGroupItem extends React.Component {
       <RSListGroupItem
         tag={useLink ? Link : 'li'}
         target={useLink && target}
-        {...omit(['setProps'], otherProps)}
+        {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }
@@ -38,6 +38,11 @@ class ListGroupItem extends React.Component {
     );
   }
 }
+
+ListGroupItem.defaultProps = {
+  n_clicks: 0,
+  n_clicks_timestamp: -1
+};
 
 ListGroupItem.propTypes = {
   /**

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -36,7 +36,7 @@ class NavLink extends React.Component {
       <Link
         className={classes}
         preOnClick={this.incrementClicks}
-        {...omit(['setProps'], otherProps)}
+        {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
         data-dash-is-loading={
           (loading_state && loading_state.is_loading) || undefined
         }

--- a/src/private/Link.js
+++ b/src/private/Link.js
@@ -46,7 +46,7 @@ class Link extends Component {
       this.props.preOnClick();
     }
     const {external_link, href} = this.props;
-    if (!isExternalLink(external_link, href)) {
+    if (href && !isExternalLink(external_link, href)) {
       // prevent anchor from updating location
       e.preventDefault();
       const {href} = this.props;
@@ -74,7 +74,7 @@ class Link extends Component {
     return (
       <a
         href={href}
-        target={isExternalLink(external_link, href) && target}
+        target={href && isExternalLink(external_link, href) ? target : null}
         {...otherProps}
         onClick={e => this.updateLocation(e)}
       >


### PR DESCRIPTION
This PR makes some improvements to link based components, in particular ensuring that `isExternalLink` in `Link` won't fail if no `href` is supplied, and making sure that the appropriate fallback elements as used if `Link` isn't used.