### PR TITLE
Load landing-page.md as utf8

### DIFF
--- a/landing-page.md
+++ b/landing-page.md
@@ -9,8 +9,8 @@
 <p align="center">
   Bootstrap components for Plotly Dash
   <br>
-  <a href="https://dash-bootstrap-components.opensource.faculty.ai/">Explore the documentation</a>
-  <a href="https://github.com/facultyai/dash-bootstrap-components/issues/new?template=bug.md">Report a bug</a>
+  <a href="https://dash-bootstrap-components.opensource.faculty.ai/">Explore the documentation </a>~
+  <a href="https://github.com/facultyai/dash-bootstrap-components/issues/new?template=bug.md">Report a bug </a>~
   <a href="https://github.com/facultyai/dash-bootstrap-components/issues/new?template=feature.md">Request a feature</a>
   <br>
   <br>

--- a/landing-page.md
+++ b/landing-page.md
@@ -10,9 +10,7 @@
   Bootstrap components for Plotly Dash
   <br>
   <a href="https://dash-bootstrap-components.opensource.faculty.ai/">Explore the documentation</a>
-  ·
   <a href="https://github.com/facultyai/dash-bootstrap-components/issues/new?template=bug.md">Report a bug</a>
-  ·
   <a href="https://github.com/facultyai/dash-bootstrap-components/issues/new?template=feature.md">Request a feature</a>
   <br>
   <br>

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _get_version():
 
 
 def _get_long_description():
-    with open(os.path.join(HERE, "landing-page.md")) as f:
+    with open(os.path.join(HERE, "landing-page.md"), encoding="utf8") as f:
         return f.read()
 
 


### PR DESCRIPTION
The setup script loads the contents of `landing-page.md` into the `long_description` argument of the call to `setuptools.setup` for making a nice landing page on PyPI. However it does so by calling `open` without specifying `encoding` whose default value is platform dependent. This resulted in #320  where users on platforms whose default encoding was ascii couldn't run the `setup.py` script without error.

This PR both sets the encoding explicitly, and also removes some non-ascii characters from `landing-page.md` for good measure.