### PR TITLE
Fix setup.py for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - "if [[ \"$GROUP\" == js ]] ; then npm run lint ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm run test ; fi"
   - "if [[ \"$GROUP\" == js ]] ; then npm run test:demo ; fi"
+  - "if [[ \"$GROUP\" == js ]] ; then pip install .; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then black . --check ; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then flake8 ; fi"
   - "if [[ \"$GROUP\" == python-linting ]] ; then isort -rc -c ; fi"
@@ -19,6 +20,8 @@ matrix:
   include:
     - python: 3.6
       env: GROUP=python-linting
+    - python: 2.7
+      env: GROUP=js
     - python: 3.6
       env: GROUP=js
     - python: 2.7

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from setuptools import find_packages, setup
@@ -19,7 +20,7 @@ def _get_version():
 
 
 def _get_long_description():
-    with open(os.path.join(HERE, "landing-page.md"), encoding="utf8") as f:
+    with io.open(os.path.join(HERE, "landing-page.md"), encoding="utf8") as f:
         return f.read()
 
 


### PR DESCRIPTION
Previous release broke the `setup.py` script for Python 2, this fixes it. I considered dropping support for Python 2, but since Dash continues to support it for now and it seems a non-negligible number of downloads from PyPI are for Python 2 it's probably worth patching.