### PR TITLE
Bump werkzeug version in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ gunicorn
 markdown
 pandas
 scikit-learn
+werkzeug>=1.0.0


### PR DESCRIPTION
The deployed docs app had an old version of `werkzeug`, bumping the version requirement