### PR TITLE
Expose some missing props

### DIFF
--- a/src/components/Jumbotron.js
+++ b/src/components/Jumbotron.js
@@ -35,6 +35,11 @@ Jumbotron.propTypes = {
   children: PropTypes.node,
 
   /**
+   * Defines CSS styles which will override styles previously set.
+   */
+  style: PropTypes.object,
+
+  /**
    * If True, the jumbotron will grow to use the entire
    * horizontal space of its parent. Default: False.
    */

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -471,7 +471,12 @@ Input.propTypes = {
    * local: window.localStorage, data is kept after the browser quit.
    * session: window.sessionStorage, data is cleared once the browser quit.
    */
-  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
+
+  /**
+   * Overrides the browser's default tab order and follows the one specified instead.
+   */
+  tabIndex: PropTypes.string
 };
 
 Input.defaultProps = {


### PR DESCRIPTION
`style` argument for `Jumbotron` and `tabIndex` for `Input`, addressing #341 and #343 respectively