### PR TITLE
Support persistence in Checkbox and RadioButton

### DIFF
--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -22,7 +22,17 @@ class Checkbox extends React.Component {
       <input
         type="checkbox"
         checked={checked}
-        {...omit(['checked', 'setProps', 'loading_state'], this.props)}
+        {...omit(
+          [
+            'checked',
+            'setProps',
+            'loading_state',
+            'persistence',
+            'persistence_type',
+            'persisted_props'
+          ],
+          this.props
+        )}
         onClick={() => {
           if (this.props.setProps) {
             this.props.setProps({
@@ -40,6 +50,11 @@ class Checkbox extends React.Component {
     );
   }
 }
+
+Checkbox.defaultProps = {
+  persisted_props: ['checked'],
+  persistence_type: 'local'
+};
 
 Checkbox.propTypes = {
   /**
@@ -92,7 +107,36 @@ Checkbox.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['checked'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Checkbox;

--- a/src/components/input/RadioButton.js
+++ b/src/components/input/RadioButton.js
@@ -22,7 +22,17 @@ class RadioButton extends React.Component {
       <input
         type="radio"
         checked={checked}
-        {...omit(['checked', 'setProps', 'loading_state'], this.props)}
+        {...omit(
+          [
+            'checked',
+            'setProps',
+            'loading_state',
+            'persistence',
+            'persistence_type',
+            'persisted_props'
+          ],
+          this.props
+        )}
         onClick={() => {
           if (this.props.setProps) {
             this.props.setProps({
@@ -40,6 +50,11 @@ class RadioButton extends React.Component {
     );
   }
 }
+
+RadioButton.defaultProps = {
+  persisted_props: ['checked'],
+  persistence_type: 'local'
+};
 
 RadioButton.propTypes = {
   /**
@@ -91,7 +106,36 @@ RadioButton.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['checked'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default RadioButton;


### PR DESCRIPTION
This PR adds support for persistence to `Checkbox` and `RadioButton`, enabled by plotly/dash#1142.