### PR TITLE
Fix to minimal example

### DIFF
--- a/docs/content/docs/dashR.md
+++ b/docs/content/docs/dashR.md
@@ -8,7 +8,7 @@ You can now use _dash-bootstrap-components_ with Dash for R! Note that support f
 
 ## Installation
 
-To get started make sure you have the _devtools_ library installed
+To get started make sure you have [installed Dash for R](https://dashr.plotly.com/installation). If you didn't already install it in order to install Dash for R, we also need to make sure that the _devtools_ library is installed.
 
 ```r
 install.packages("devtools")
@@ -59,6 +59,7 @@ With CSS linked, you can start building you app's layout with out Bootstrap comp
 ```r
 library(dash)
 library(dashBootstrapComponents)
+library(dashHtmlComponents)
 
 app <- Dash$new(external_stylesheets = dbcThemes$BOOTSTRAP)
 


### PR DESCRIPTION
Dash for R fails if _dashHtmlComponents_ is not loaded. This PR amends the minimal example accordingly as suggested in #370 