### PR TITLE
Allow ids for labels and inputs to be set in RadioItems and Checklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
     "gulp-rename": "^2.0.0",
     "jest": "^24.9.0",
     "mkdirp": "^0.5.4",
-    "node-sass": "^4.13.1",
+    "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "react-docgen": "^2.21.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -47,9 +47,12 @@ class Checklist extends React.Component {
       : labelStyle;
 
     if (id && custom) {
+      const inputId =
+        option.input_id || `_dbcprivate_checklist_${id}_input_${option.value}`;
       return (
         <CustomInput
-          id={`_${id}-${option.value}`}
+          id={inputId}
+          labelId={option.label_id}
           checked={checked}
           className={inputClassName}
           disabled={Boolean(option.disabled)}
@@ -75,8 +78,9 @@ class Checklist extends React.Component {
       );
     } else {
       // it shouldn't ever really happen that an id isn't supplied, but in case
-      // it is we use _dbcprivate_checklist
-      const inputId = `_${id || "_dbcprivate_checklist"}-${option.value}`
+      // it isn't we use _dbcprivate_checklist
+      const inputId =
+        option.input_id || `_dbcprivate_checklist_${id}_input_${option.value}`;
       return (
         <div
           className={classNames('form-check', inline && 'form-check-inline')}
@@ -100,6 +104,7 @@ class Checklist extends React.Component {
             }}
           />
           <label
+            id={option.label_id}
             style={mergedLabelStyle}
             className={classNames(
               'form-check-label',
@@ -165,7 +170,19 @@ Checklist.propTypes = {
       /**
        * If true, this checkbox is disabled and can't be clicked on.
        */
-      disabled: PropTypes.bool
+      disabled: PropTypes.bool,
+
+      /**
+       * id for this option's input, can be used to attach tooltips or apply
+       * CSS styles
+       */
+      input_id: PropTypes.string,
+
+      /**
+       * id for this option's label, can be used to attach tooltips or apply
+       * CSS styles
+       */
+      label_id: PropTypes.string
     })
   ),
 

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -40,9 +40,12 @@ class RadioItems extends React.Component {
       : labelStyle;
 
     if (id && custom) {
+      const inputId =
+        option.input_id || `_dbcprivate_radioitems_${id}_input_${option.value}`;
       return (
         <CustomInput
-          id={`${id}-${option.value}`}
+          id={inputId}
+          labelId={option.label_id}
           checked={checked}
           className={inputClassName}
           disabled={Boolean(option.disabled)}
@@ -62,8 +65,9 @@ class RadioItems extends React.Component {
       );
     } else {
       // it shouldn't ever really happen that an id isn't supplied, but in case
-      // it is we use _dbcprivate_checklist
-      const inputId = `_${id || '_dbcprivate_radioitems'}-${option.value}`;
+      // it is we use _dbcprivate_radioitems
+      const inputId =
+        option.input_id || `_dbcprivate_radioitems_${id}_input_${option.value}`;
       return (
         <div
           className={classNames('form-check', inline && 'form-check-inline')}
@@ -81,6 +85,7 @@ class RadioItems extends React.Component {
             }}
           />
           <label
+            id={option.label_id}
             style={mergedLabelStyle}
             className={classNames(
               'form-check-label',
@@ -153,7 +158,19 @@ RadioItems.propTypes = {
       /**
        * If true, this radio item is disabled and can't be clicked on.
        */
-      disabled: PropTypes.bool
+      disabled: PropTypes.bool,
+
+      /**
+       * id for this option's input, can be used to attach tooltips or apply
+       * CSS styles
+       */
+      input_id: PropTypes.string,
+
+      /**
+       * id for this option's label, can be used to attach tooltips or apply
+       * CSS styles
+       */
+      label_id: PropTypes.string
     })
   ),
 

--- a/src/private/CustomInput.js
+++ b/src/private/CustomInput.js
@@ -13,6 +13,7 @@ const CustomInput = props => {
     bsSize,
     innerRef,
     htmlFor,
+    labelId,
     labelStyle,
     labelClassName,
     ...attributes
@@ -68,6 +69,7 @@ const CustomInput = props => {
         className={classNames(validationClassNames, 'custom-control-input')}
       />
       <label
+        id={labelId}
         className={classNames('custom-control-label', labelClassName)}
         style={labelStyle}
         htmlFor={labelHtmlFor}
@@ -100,6 +102,7 @@ CustomInput.propTypes = {
     PropTypes.string,
     PropTypes.func
   ]),
+  labelId: PropTypes.string,
   labelStyle: PropTypes.object,
   labelClassName: PropTypes.string
 };


### PR DESCRIPTION
To allow for example tooltips to be attached to labels as pointed out in #377 