### PR TITLE
Remove dashHtmlComponents from simple example

### DIFF
--- a/docs/content/docs/dashR.md
+++ b/docs/content/docs/dashR.md
@@ -59,7 +59,6 @@ With CSS linked, you can start building you app's layout with out Bootstrap comp
 ```r
 library(dash)
 library(dashBootstrapComponents)
-library(dashHtmlComponents)
 
 app <- Dash$new(external_stylesheets = dbcThemes$BOOTSTRAP)
 


### PR DESCRIPTION
Revert dash for R example thanks to changes detailed in #370 