### PR TITLE
[WIP] Functionalise

### DIFF
--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Alert as RSAlert} from 'reactstrap';
@@ -9,62 +9,49 @@ import {Alert as RSAlert} from 'reactstrap';
  * Control the visibility using callbacks with the `is_open` prop, or set it to
  * auto-dismiss with the `duration` prop.
  */
-class Alert extends React.Component {
-  constructor(props) {
-    super(props);
+const Alert = props => {
+  const {
+    children,
+    dismissable,
+    duration,
+    is_open,
+    loading_state,
+    setProps,
+    ...otherProps
+  } = props;
 
-    this.dismiss = this.dismiss.bind(this);
+  const [alertOpen, setAlertOpen] = useState(is_open);
 
-    this.state = {
-      alertOpen: props.is_open
-    };
-  }
+  useEffect(() => {
+    if (is_open != alertOpen) {
+      setAlertOpen(is_open);
+    }
+    if (is_open && duration) {
+      setTimeout(dismiss, duration);
+    }
+  }, [is_open]);
 
-  dismiss() {
-    if (this.props.setProps) {
-      this.props.setProps({is_open: false});
+  const dismiss = () => {
+    if (setProps) {
+      setProps({is_open: false});
     } else {
-      this.setState({alertOpen: false});
+      setAlertOpen(false);
     }
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.is_open != this.state.alertOpen) {
-      this.setState({alertOpen: nextProps.is_open});
-      if (nextProps.is_open && this.props.duration) {
-        setTimeout(this.dismiss, this.props.duration);
+  return (
+    <RSAlert
+      isOpen={alertOpen}
+      toggle={dismissable && dismiss}
+      {...omit(['setProps'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
       }
-    }
-  }
-
-  componentDidMount() {
-    if (this.props.is_open && this.props.duration) {
-      setTimeout(this.dismiss, this.props.duration);
-    }
-  }
-
-  render() {
-    const {
-      children,
-      dismissable,
-      is_open,
-      loading_state,
-      ...otherProps
-    } = this.props;
-    return (
-      <RSAlert
-        isOpen={this.state.alertOpen}
-        toggle={dismissable && this.dismiss}
-        {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {children}
-      </RSAlert>
-    );
-  }
-}
+    >
+      {children}
+    </RSAlert>
+  );
+};
 
 Alert.defaultProps = {
   is_open: true,

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Alert as RSAlert} from 'reactstrap';
@@ -20,28 +20,28 @@ const Alert = props => {
     ...otherProps
   } = props;
 
-  const [alertOpen, setAlertOpen] = useState(is_open);
+  const timeout = useRef(null);
 
   useEffect(() => {
-    if (is_open != alertOpen) {
-      setAlertOpen(is_open);
-    }
-    if (is_open && duration) {
-      setTimeout(dismiss, duration);
+    if (duration) {
+      if (is_open) {
+        timeout.current = setTimeout(dismiss, duration);
+      } else if (timeout.current) {
+        clearTimeout(timeout.current);
+        timeout.current = null;
+      }
     }
   }, [is_open]);
 
   const dismiss = () => {
     if (setProps) {
       setProps({is_open: false});
-    } else {
-      setAlertOpen(false);
     }
   };
 
   return (
     <RSAlert
-      isOpen={alertOpen}
+      isOpen={is_open}
       toggle={dismissable && dismiss}
       {...omit(['setProps'], otherProps)}
       data-dash-is-loading={

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Toast as RSToast, ToastBody, ToastHeader} from 'reactstrap';
@@ -8,75 +8,62 @@ import {Toast as RSToast, ToastBody, ToastHeader} from 'reactstrap';
  * visibility of the toast with the `is_open` prop, or use `duration` to set a
  * timer for auto-dismissal.
  */
-class Toast extends React.Component {
-  constructor(props) {
-    super(props);
+const Toast = props => {
+  const {
+    children,
+    header,
+    icon,
+    header_style,
+    headerClassName,
+    body_style,
+    bodyClassName,
+    dismissable,
+    duration,
+    n_dismiss,
+    is_open,
+    setProps,
+    ...otherProps
+  } = props;
 
-    this.dismiss = this.dismiss.bind(this);
-    this.state = {
-      toastOpen: props.is_open
-    };
-  }
+  const [toastOpen, setToastOpen] = useState(is_open);
 
-  dismiss() {
-    if (this.props.setProps) {
-      this.props.setProps({
+  useEffect(() => {
+    if (is_open != toastOpen) {
+      setToastOpen(is_open);
+    }
+    if (is_open && duration) {
+      setTimeout(dismiss, duration);
+    }
+  }, [is_open]);
+
+  const dismiss = () => {
+    if (setProps) {
+      setProps({
         is_open: false,
-        n_dismiss: this.props.n_dismiss + 1,
+        n_dismiss: n_dismiss + 1,
         n_dismiss_timestamp: Date.now()
       });
     } else {
-      this.setState({toastOpen: false});
+      setToastOpen(false);
     }
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.is_open != this.state.toastOpen) {
-      this.setState({toastOpen: nextProps.is_open});
-      if (nextProps.is_open && this.props.duration) {
-        setTimeout(this.dismiss, this.props.duration);
-      }
-    }
-  }
-
-  componentDidMount() {
-    if (this.props.is_open && this.props.duration) {
-      setTimeout(this.dismiss, this.props.duration);
-    }
-  }
-
-  render() {
-    const {
-      children,
-      header,
-      icon,
-      header_style,
-      headerClassName,
-      body_style,
-      bodyClassName,
-      dismissable,
-      ...otherProps
-    } = this.props;
-    return (
-      <RSToast
-        isOpen={this.state.toastOpen}
-        {...omit(['setProps', 'is_open'], otherProps)}
+  return (
+    <RSToast isOpen={toastOpen} {...omit(['n_dismiss_timestamp'], otherProps)}>
+      <ToastHeader
+        icon={icon}
+        style={header_style}
+        className={headerClassName}
+        toggle={dismissable && dismiss}
       >
-        <ToastHeader
-          icon={icon}
-          style={header_style}
-          className={headerClassName}
-          toggle={dismissable && this.dismiss}
-        >
-          {header}
-        </ToastHeader>
-        <ToastBody style={body_style} className={bodyClassName}>
-          {children}
-        </ToastBody>
-      </RSToast>
-    );
-  }
-}
+        {header}
+      </ToastHeader>
+      <ToastBody style={body_style} className={bodyClassName}>
+        {children}
+      </ToastBody>
+    </RSToast>
+  );
+};
 
 Toast.defaultProps = {
   is_open: true,

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Toast as RSToast, ToastBody, ToastHeader} from 'reactstrap';
@@ -25,17 +25,6 @@ const Toast = props => {
     ...otherProps
   } = props;
 
-  const [toastOpen, setToastOpen] = useState(is_open);
-
-  useEffect(() => {
-    if (is_open != toastOpen) {
-      setToastOpen(is_open);
-    }
-    if (is_open && duration) {
-      setTimeout(dismiss, duration);
-    }
-  }, [is_open]);
-
   const dismiss = () => {
     if (setProps) {
       setProps({
@@ -43,13 +32,24 @@ const Toast = props => {
         n_dismiss: n_dismiss + 1,
         n_dismiss_timestamp: Date.now()
       });
-    } else {
-      setToastOpen(false);
     }
   };
 
+  const timeout = useRef(null);
+
+  useEffect(() => {
+    if (duration) {
+      if (is_open) {
+        timeout.current = setTimeout(dismiss, duration);
+      } else if (timeout.current) {
+        clearTimeout(timeout.current);
+        timeout.current = null;
+      }
+    }
+  }, [is_open]);
+
   return (
-    <RSToast isOpen={toastOpen} {...omit(['n_dismiss_timestamp'], otherProps)}>
+    <RSToast isOpen={is_open} {...omit(['n_dismiss_timestamp'], otherProps)}>
       <ToastHeader
         icon={icon}
         style={header_style}

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Tooltip as RSTooltip} from 'reactstrap';
@@ -9,47 +9,37 @@ import {Tooltip as RSTooltip} from 'reactstrap';
  * Simply add the Tooltip to you layout, and give it a target (id of a
  * component to which the tooltip should be attached)
  */
-class Tooltip extends React.Component {
-  constructor(props) {
-    super(props);
+const Tooltip = props => {
+  const {
+    id,
+    children,
+    hide_arrow,
+    boundaries_element,
+    loading_state,
+    ...otherProps
+  } = props;
 
-    this.toggle = this.toggle.bind(this);
-    this.state = {
-      tooltipOpen: false
-    };
-  }
+  const [tooltipOpen, setTooltipOpen] = useState(false);
 
-  toggle() {
-    this.setState({
-      tooltipOpen: !this.state.tooltipOpen
-    });
-  }
+  const toggle = () => {
+    setTooltipOpen(!tooltipOpen);
+  };
 
-  render() {
-    const {
-      id,
-      children,
-      hide_arrow,
-      boundaries_element,
-      loading_state,
-      ...otherProps
-    } = this.props;
-    return (
-      <RSTooltip
-        toggle={this.toggle}
-        isOpen={this.state.tooltipOpen}
-        hideArrow={hide_arrow}
-        boundariesElement={boundaries_element}
-        {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {children}
-      </RSTooltip>
-    );
-  }
-}
+  return (
+    <RSTooltip
+      toggle={toggle}
+      isOpen={tooltipOpen}
+      hideArrow={hide_arrow}
+      boundariesElement={boundaries_element}
+      {...omit(['setProps'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {children}
+    </RSTooltip>
+  );
+};
 
 Tooltip.propTypes = {
   /**

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Tooltip as RSTooltip} from 'reactstrap';

--- a/src/components/__tests__/Alert.test.js
+++ b/src/components/__tests__/Alert.test.js
@@ -48,12 +48,27 @@ describe('Alert', () => {
   });
 
   test('self dismisses if duration is set', () => {
-    const alert = render(<Alert duration={5000} />);
+    const mockSetProps = jest.fn();
+    const alert = render(<Alert duration={5000} setProps={mockSetProps} />);
 
     // alert exists and timeout is set with duration 5000
     expect(alert.container.querySelector('.alert')).not.toBe(null);
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
 
+    act(() => jest.advanceTimersByTime(4000));
+    // alert hasn't dismissed yet
+    expect(mockSetProps.mock.calls).toHaveLength(0);
+
+    act(() => jest.advanceTimersByTime(1000));
+    // alert has dismissed
+    expect(mockSetProps.mock.calls).toHaveLength(1);
+    expect(mockSetProps.mock.calls[0][0]).toEqual({is_open: false});
+
+    alert.rerender(
+      <Alert duration={5000} setProps={mockSetProps} is_open={false} />
+    );
+
+    // necessary to skip over fade animation
     act(() => jest.runAllTimers());
 
     // after timeout has run alert no longer displays

--- a/src/components/__tests__/Alert.test.js
+++ b/src/components/__tests__/Alert.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from '@testing-library/react';
+import {act, render} from '@testing-library/react';
 import Alert from '../Alert';
 
 jest.useFakeTimers();
@@ -24,9 +24,15 @@ describe('Alert', () => {
   });
 
   test('applies contextual colors with "color" prop', () => {
-    const {container: {firstChild: alertPrimary}} = render(<Alert color="primary" />);
-    const {container: {firstChild: alertSuccess}} = render(<Alert color="success" />);
-    const {container: {firstChild: alertDark}} = render(<Alert color="dark" />);
+    const {
+      container: {firstChild: alertPrimary}
+    } = render(<Alert color="primary" />);
+    const {
+      container: {firstChild: alertSuccess}
+    } = render(<Alert color="success" />);
+    const {
+      container: {firstChild: alertDark}
+    } = render(<Alert color="dark" />);
 
     expect(alertPrimary).toHaveClass('alert-primary');
     expect(alertSuccess).toHaveClass('alert-success');
@@ -48,7 +54,7 @@ describe('Alert', () => {
     expect(alert.container.querySelector('.alert')).not.toBe(null);
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     // after timeout has run alert no longer displays
     expect(alert.container.querySelector('.alert')).toBe(null);

--- a/src/components/__tests__/Toast.test.js
+++ b/src/components/__tests__/Toast.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from '@testing-library/react';
+import {act, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Toast from '../Toast';
 
@@ -78,7 +78,7 @@ describe('Toast', () => {
     expect(toast.container.querySelector('.toast')).not.toBe(null);
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     // after timeout has run toast no longer displays
     expect(toast.container.querySelector('.toast')).toBe(null);

--- a/src/components/__tests__/Toast.test.js
+++ b/src/components/__tests__/Toast.test.js
@@ -72,12 +72,27 @@ describe('Toast', () => {
   });
 
   test('self dismisses if duration is set', () => {
-    const toast = render(<Toast duration={5000} />);
+    const mockSetProps = jest.fn();
+    const toast = render(<Toast duration={5000} setProps={mockSetProps} />);
 
     // toast exists and timeout is set with duration 5000
     expect(toast.container.querySelector('.toast')).not.toBe(null);
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
 
+    act(() => jest.advanceTimersByTime(4000));
+    // toast hasn't dismissed yet
+    expect(mockSetProps.mock.calls).toHaveLength(0);
+
+    act(() => jest.advanceTimersByTime(1000));
+    // toast has dismissed
+    expect(mockSetProps.mock.calls).toHaveLength(1);
+    expect(mockSetProps.mock.calls[0][0].is_open).toEqual(false);
+
+    toast.rerender(
+      <Toast duration={5000} setProps={mockSetProps} is_open={false} />
+    );
+
+    // necessary to skip fade animation
     act(() => jest.runAllTimers());
 
     // after timeout has run toast no longer displays

--- a/src/components/__tests__/Tooltip.test.js
+++ b/src/components/__tests__/Tooltip.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
+import {act, fireEvent, render} from '@testing-library/react';
 import Tooltip from '../Tooltip';
 
 jest.useFakeTimers();
@@ -42,13 +42,13 @@ describe('Tooltip', () => {
     });
 
     fireEvent.mouseOver(div);
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(document.body.querySelector('div.tooltip')).not.toBe(null);
     expect(document.body.querySelector('div.tooltip-inner')).not.toBe(null);
 
     fireEvent.mouseLeave(div);
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(document.body.querySelector('.tooltip')).toBe(null);
     expect(document.body.querySelector('.tooltip-inner')).toBe(null);
@@ -60,13 +60,13 @@ describe('Tooltip', () => {
     });
 
     fireEvent.focusIn(div);
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(document.body.querySelector('div.tooltip')).not.toBe(null);
     expect(document.body.querySelector('div.tooltip-inner')).not.toBe(null);
 
     fireEvent.focusOut(div);
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(document.body.querySelector('.tooltip')).toBe(null);
     expect(document.body.querySelector('.tooltip-inner')).toBe(null);
@@ -78,7 +78,7 @@ describe('Tooltip', () => {
     });
 
     fireEvent.mouseOver(div);
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(document.body.querySelector('.tooltip-inner')).toHaveTextContent(
       'Tooltip content'

--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Dropdown, DropdownToggle} from 'reactstrap';
@@ -9,81 +9,67 @@ import {DropdownMenuContext} from '../../private/DropdownMenuContext';
  * DropdownMenu creates an overlay useful for grouping together links and other
  * content to organise navigation or other interactive elements.
  */
-class DropdownMenu extends React.Component {
-  constructor(props) {
-    super(props);
+const DropdownMenu = props => {
+  const {
+    children,
+    nav,
+    label,
+    disabled,
+    caret,
+    in_navbar,
+    addon_type,
+    bs_size,
+    right,
+    loading_state,
+    color,
+    toggle_style,
+    toggleClassName,
+    ...otherProps
+  } = props;
 
-    this.toggle = this.toggle.bind(this);
-    this.getContextValue = this.getContextValue.bind(this);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
-    this.state = {
-      dropdownOpen: false
-    };
-  }
-
-  toggle() {
-    if (!this.props.disabled) {
-      this.setState(prevState => ({
-        dropdownOpen: !prevState.dropdownOpen
-      }));
+  const toggle = () => {
+    if (!disabled) {
+      setDropdownOpen(!dropdownOpen);
     }
-  }
+  };
 
-  getContextValue() {
-    return {
-      toggle: this.toggle,
-      isOpen: this.state.dropdownOpen
-    };
-  }
-
-  render() {
-    const {
-      children,
-      nav,
-      label,
-      disabled,
-      caret,
-      in_navbar,
-      addon_type,
-      bs_size,
-      right,
-      loading_state,
-      color,
-      toggle_style,
-      toggleClassName,
-      ...otherProps
-    } = this.props;
-    return (
-      <DropdownMenuContext.Provider value={this.getContextValue()}>
-        <Dropdown
-          isOpen={this.state.dropdownOpen}
-          toggle={this.toggle}
+  return (
+    <DropdownMenuContext.Provider
+      value={{
+        toggle: toggle,
+        isOpen: dropdownOpen
+      }}
+    >
+      <Dropdown
+        isOpen={dropdownOpen}
+        toggle={toggle}
+        nav={nav}
+        disabled={disabled}
+        inNavbar={in_navbar}
+        addonType={addon_type}
+        size={bs_size}
+        {...omit(['setProps'], otherProps)}
+        data-dash-is-loading={
+          (loading_state && loading_state.is_loading) || undefined
+        }
+      >
+        <DropdownToggle
           nav={nav}
+          caret={caret}
           disabled={disabled}
-          inNavbar={in_navbar}
-          addonType={addon_type}
-          size={bs_size}
-          {...omit(['setProps'], otherProps)}
-          data-dash-is-loading={
-            (loading_state && loading_state.is_loading) || undefined
-          }
+          color={color}
+          style={toggle_style}
+          className={toggleClassName}
         >
-          <DropdownToggle
-            nav={nav}
-            caret={caret}
-            disabled={disabled}
-            color={color}
-            style={toggle_style}
-            className={toggleClassName}
-          >
-            {label}
-          </DropdownToggle>
-          <RSDropdownMenu right={right}>{this.props.children}</RSDropdownMenu>
-        </Dropdown>
-      </DropdownMenuContext.Provider>
-    );
-  }
-}
+          {label}
+        </DropdownToggle>
+        <RSDropdownMenu right={right}>{children}</RSDropdownMenu>
+      </Dropdown>
+    </DropdownMenuContext.Provider>
+  );
+};
 
 DropdownMenu.defaultProps = {
   caret: true,

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -32,8 +32,7 @@ const DropdownMenuItem = props => {
         n_clicks_timestamp: Date.now()
       });
     }
-    const {external_link, href} = props;
-    if (href && !isExternalLink(external_link, href)) {
+    if (props.href) {
       if (toggle && context.isOpen) {
         context.toggle(e);
       }
@@ -58,13 +57,6 @@ const DropdownMenuItem = props => {
     </RSDropdownItem>
   );
 };
-class OldDropdownMenuItem extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.handleClick = this.handleClick.bind(this);
-  }
-}
 
 DropdownMenuItem.propTypes = {
   /**

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {DropdownItem as RSDropdownItem} from 'reactstrap';
@@ -9,47 +9,60 @@ import {DropdownMenuContext} from '../../private/DropdownMenuContext';
 /**
  * Use DropdownMenuItem to build up the content of a DropdownMenu.
  */
-class DropdownMenuItem extends React.Component {
+const DropdownMenuItem = props => {
+  let {
+    children,
+    href,
+    external_link,
+    loading_state,
+    target,
+    disabled,
+    n_clicks,
+    toggle,
+    setProps,
+    ...otherProps
+  } = props;
+
+  const context = useContext(DropdownMenuContext);
+
+  const handleClick = e => {
+    if (!disabled && setProps) {
+      setProps({
+        n_clicks: n_clicks + 1,
+        n_clicks_timestamp: Date.now()
+      });
+    }
+    const {external_link, href} = props;
+    if (href && !isExternalLink(external_link, href)) {
+      if (toggle && context.isOpen) {
+        context.toggle(e);
+      }
+    }
+  };
+
+  const useLink = href && !disabled;
+  otherProps[useLink ? 'preOnClick' : 'onClick'] = e => handleClick(e);
+  return (
+    <RSDropdownItem
+      tag={useLink ? Link : 'button'}
+      // don't pass href if disabled otherwise reactstrap renders item
+      // as link and the cursor becomes a pointer on hover
+      href={disabled ? null : href}
+      target={useLink && target}
+      {...omit(['setProps'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {children}
+    </RSDropdownItem>
+  );
+};
+class OldDropdownMenuItem extends React.Component {
   constructor(props) {
     super(props);
 
     this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick(e) {
-    if (!this.props.disabled && this.props.setProps) {
-      this.props.setProps({
-        n_clicks: this.props.n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
-    }
-    const {external_link, href} = this.props;
-    if (href && !isExternalLink(external_link, href)) {
-      if (this.props.toggle && this.context.isOpen) {
-        this.context.toggle(e);
-      }
-    }
-  }
-
-  render() {
-    let {children, href, loading_state, target, ...otherProps} = this.props;
-    const useLink = href && !this.props.disabled;
-    otherProps[useLink ? 'preOnClick' : 'onClick'] = e => this.handleClick(e);
-    return (
-      <RSDropdownItem
-        tag={useLink ? Link : 'button'}
-        // don't pass href if disabled otherwise reactstrap renders item
-        // as link and the cursor becomes a pointer on hover
-        href={this.props.disabled ? null : href}
-        target={useLink && target}
-        {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {children}
-      </RSDropdownItem>
-    );
   }
 }
 
@@ -167,7 +180,5 @@ DropdownMenuItem.defaultProps = {
   n_clicks_timestamp: -1,
   toggle: true
 };
-
-DropdownMenuItem.contextType = DropdownMenuContext;
 
 export default DropdownMenuItem;

--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -1,55 +1,39 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
 /**
  * Creates a single checkbox input. Use the `checked` prop in your callbacks.
  */
-class Checkbox extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {checked: props.checked};
-  }
+const Checkbox = props => {
+  const {checked, loading_state, setProps, ...otherProps} = props;
+  const [checkedState, setCheckedState] = useState(checked);
 
-  componentWillReceiveProps(newProps) {
-    this.setState({checked: newProps.checked});
-  }
+  useEffect(() => setCheckedState(checked), [checked]);
 
-  render() {
-    const {checked} = this.state;
-
-    return (
-      <input
-        type="checkbox"
-        checked={checked}
-        {...omit(
-          [
-            'checked',
-            'setProps',
-            'loading_state',
-            'persistence',
-            'persistence_type',
-            'persisted_props'
-          ],
-          this.props
-        )}
-        onClick={() => {
-          if (this.props.setProps) {
-            this.props.setProps({
-              checked: !checked
-            });
-          } else {
-            this.setState({checked: !checked});
-          }
-        }}
-        data-dash-is-loading={
-          (this.props.loading_state && this.props.loading_state.is_loading) ||
-          undefined
+  return (
+    <input
+      type="checkbox"
+      defaultChecked={checkedState}
+      {...omit(
+        ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
+        otherProps
+      )}
+      onChange={() => {
+        if (setProps) {
+          setProps({
+            checked: !checkedState
+          });
+        } else {
+          setCheckedState(!checkedState);
         }
-      />
-    );
-  }
-}
+      }}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    />
+  );
+};
 
 Checkbox.defaultProps = {
   persisted_props: ['checked'],

--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
@@ -7,14 +7,11 @@ import {omit} from 'ramda';
  */
 const Checkbox = props => {
   const {checked, loading_state, setProps, ...otherProps} = props;
-  const [checkedState, setCheckedState] = useState(checked);
-
-  useEffect(() => setCheckedState(checked), [checked]);
 
   return (
     <input
       type="checkbox"
-      defaultChecked={checkedState}
+      defaultChecked={checked}
       {...omit(
         ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
         otherProps
@@ -22,10 +19,8 @@ const Checkbox = props => {
       onChange={() => {
         if (setProps) {
           setProps({
-            checked: !checkedState
+            checked: !checked
           });
-        } else {
-          setCheckedState(!checkedState);
         }
       }}
       data-dash-is-loading={
@@ -36,6 +31,7 @@ const Checkbox = props => {
 };
 
 Checkbox.defaultProps = {
+  checked: false,
   persisted_props: ['checked'],
   persistence_type: 'local'
 };

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -17,14 +17,10 @@ import CustomInput from '../../private/CustomInput';
  *
  * https://getbootstrap.com/docs/4.4/components/forms/#checkboxes-and-radios-1
  */
-class Checklist extends React.Component {
-  constructor(props) {
-    super(props);
+const Checklist = props => {
+  const {className, id, options, style, key, loading_state} = props;
 
-    this.listItem = this.listItem.bind(this);
-  }
-
-  listItem(option) {
+  const listItem = option => {
     const {
       id,
       inputClassName,
@@ -38,7 +34,7 @@ class Checklist extends React.Component {
       value,
       custom,
       switch: switches
-    } = this.props;
+    } = props;
 
     const checked = contains(option.value, value);
 
@@ -119,28 +115,23 @@ class Checklist extends React.Component {
         </div>
       );
     }
-  }
+  };
+  const items = options.map(option => listItem(option));
 
-  render() {
-    const {className, id, options, style, key, loading_state} = this.props;
-
-    const items = options.map(option => this.listItem(option));
-
-    return (
-      <div
-        id={id}
-        style={style}
-        className={className}
-        key={key}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {items}
-      </div>
-    );
-  }
-}
+  return (
+    <div
+      id={id}
+      style={style}
+      className={className}
+      key={key}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {items}
+    </div>
+  );
+};
 
 Checklist.propTypes = {
   /**

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit, isEmpty} from 'ramda';
 import isNumeric from 'fast-isnumeric';
@@ -16,140 +16,112 @@ const convert = val => (isNumeric(val) ? +val : NaN);
  * the Checklist and RadioItems component. Dates, times, and file uploads
  * are supported through separate components in other libraries.
  */
-class Input extends React.Component {
-  constructor(props) {
-    super(props);
+const Input = props => {
+  const {
+    value,
+    className,
+    debounce,
+    n_blur,
+    n_submit,
+    valid,
+    invalid,
+    bs_size,
+    plaintext,
+    loading_state,
+    setProps,
+    ...otherProps
+  } = props;
 
-    this.onBlur = this.onBlur.bind(this);
-    this.onChange = this.onChange.bind(this);
-    this.onKeyPress = this.onKeyPress.bind(this);
-    this.parseValue = this.parseValue.bind(this);
+  const [valueState, setValueState] = useState(value);
 
-    this.state = {value: props.value};
-  }
+  useEffect(() => setValueState(value), [value]);
 
-  parseValue(value) {
-    if (this.props.type === 'number') {
+  const parseValue = value => {
+    if (props.type === 'number') {
       const convertedValue = convert(value);
       if (isNaN(convertedValue)) {
         return;
-      }
-      else if (
-        (!isEmpty(this.props.min) && convertedValue < this.props.min) ||
-        (!isEmpty(this.props.max) && convertedValue > this.props.max)
+      } else if (
+        (!isEmpty(props.min) && convertedValue < props.min) ||
+        (!isEmpty(props.max) && convertedValue > props.max)
       ) {
         return;
-      }
-      else return convertedValue;
+      } else return convertedValue;
     } else return value;
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.value != this.state.value) {
-      this.setState({value: nextProps.value});
-    }
-  }
-
-  render() {
-    const {
-      className,
-      valid,
-      invalid,
-      bs_size,
-      plaintext,
-      loading_state
-    } = this.props;
-
-    let formControlClass = 'form-control';
-
-    if (plaintext) {
-      formControlClass = `${formControlClass}-plaintext`;
-    }
-
-    const classes = classNames(
-      className,
-      invalid && 'is-invalid',
-      valid && 'is-valid',
-      bs_size ? `form-control-${bs_size}` : false,
-      formControlClass
-    );
-    return (
-      <input
-        onChange={this.onChange}
-        onBlur={this.onBlur}
-        onKeyPress={this.onKeyPress}
-        className={classes}
-        value={this.state.value}
-        {...omit(
-          [
-            'debounce',
-            'n_blur',
-            'n_blur_timestamp',
-            'n_submit',
-            'n_submit_timestamp',
-            'selectionDirection',
-            'selectionEnd',
-            'selectionStart',
-            'setProps',
-            'value',
-            'className',
-            'valid',
-            'invalid',
-            'bs_size',
-            'plaintext',
-            'loading_state',
-            'persistence',
-            'persistence_type',
-            'persisted_props'
-          ],
-          this.props
-        )}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      />
-    );
-  }
-
-  onChange(e) {
-    const {debounce, setProps} = this.props;
-    const newValue = e.target.value;
-    const castValue = this.parseValue(newValue);
+  const onChange = e => {
+    const newValue = parseValue(e.target.value);
     if (!debounce && setProps) {
-      setProps({value: castValue});
+      setProps({value: newValue});
     } else {
-      this.setState({value: castValue});
+      setValueState(newValue);
     }
-  }
+  };
 
-  onKeyPress(e) {
-    const {setProps, debounce} = this.props;
-    if (setProps && e.key === 'Enter') {
-      const payload = {
-        n_submit: this.props.n_submit + 1,
-        n_submit_timestamp: Date.now()
-      };
-      if (debounce) {
-        payload.value = this.state.value;
-      }
-      setProps(payload);
-    }
-  }
-
-  onBlur() {
-    const {setProps, debounce} = this.props;
+  const onBlur = () => {
     if (setProps) {
       const payload = {
-        n_blur: this.props.n_blur + 1,
+        n_blur: n_blur + 1,
         n_blur_timestamp: Date.now()
       };
       if (debounce) {
-        payload.value = this.state.value;
+        payload.value = valueState;
       }
       setProps(payload);
     }
-  }
-}
+  };
+
+  const onKeyPress = e => {
+    if (setProps && e.key === 'Enter') {
+      const payload = {
+        n_submit: n_submit + 1,
+        n_submit_timestamp: Date.now()
+      };
+      if (debounce) {
+        payload.value = valueState;
+      }
+      setProps(payload);
+    }
+  };
+
+  const formControlClass = plaintext
+    ? 'form-control-plaintext'
+    : 'form-control';
+
+  const classes = classNames(
+    className,
+    invalid && 'is-invalid',
+    valid && 'is-valid',
+    bs_size ? `form-control-${bs_size}` : false,
+    formControlClass
+  );
+  return (
+    <input
+      onChange={onChange}
+      onBlur={onBlur}
+      onKeyPress={onKeyPress}
+      className={classes}
+      value={valueState}
+      {...omit(
+        [
+          'n_blur_timestamp',
+          'n_submit_timestamp',
+          'selectionDirection',
+          'selectionEnd',
+          'selectionStart',
+          'persistence',
+          'persistence_type',
+          'persisted_props'
+        ],
+        otherProps
+      )}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    />
+  );
+};
 
 Input.propTypes = {
   /**

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit, isEmpty} from 'ramda';
 import isNumeric from 'fast-isnumeric';
@@ -32,10 +32,6 @@ const Input = props => {
     ...otherProps
   } = props;
 
-  const [valueState, setValueState] = useState(value);
-
-  useEffect(() => setValueState(value), [value]);
-
   const parseValue = value => {
     if (props.type === 'number') {
       const convertedValue = convert(value);
@@ -54,19 +50,17 @@ const Input = props => {
     const newValue = parseValue(e.target.value);
     if (!debounce && setProps) {
       setProps({value: newValue});
-    } else {
-      setValueState(newValue);
     }
   };
 
-  const onBlur = () => {
+  const onBlur = e => {
     if (setProps) {
       const payload = {
         n_blur: n_blur + 1,
         n_blur_timestamp: Date.now()
       };
       if (debounce) {
-        payload.value = valueState;
+        payload.value = parseValue(e.target.value);
       }
       setProps(payload);
     }
@@ -79,7 +73,7 @@ const Input = props => {
         n_submit_timestamp: Date.now()
       };
       if (debounce) {
-        payload.value = valueState;
+        payload.value = parseValue(e.target.value);
       }
       setProps(payload);
     }
@@ -102,7 +96,7 @@ const Input = props => {
       onBlur={onBlur}
       onKeyPress={onKeyPress}
       className={classes}
-      value={valueState}
+      defaultValue={value}
       {...omit(
         [
           'n_blur_timestamp',

--- a/src/components/input/RadioButton.js
+++ b/src/components/input/RadioButton.js
@@ -1,55 +1,39 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
 /**
  * Creates a single radio button. Use the `checked` prop in your callbacks.
  */
-class RadioButton extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {checked: props.checked};
-  }
+const RadioButton = props => {
+  const {checked, loading_state, setProps, ...otherProps} = props;
+  const [checkedState, setCheckedState] = useState(checked);
 
-  componentWillReceiveProps(newProps) {
-    this.setState({checked: newProps.checked});
-  }
+  useEffect(() => setCheckedState(checked), [checked]);
 
-  render() {
-    const {checked} = this.state;
-
-    return (
-      <input
-        type="radio"
-        checked={checked}
-        {...omit(
-          [
-            'checked',
-            'setProps',
-            'loading_state',
-            'persistence',
-            'persistence_type',
-            'persisted_props'
-          ],
-          this.props
-        )}
-        onClick={() => {
-          if (this.props.setProps) {
-            this.props.setProps({
-              checked: !checked
-            });
-          } else {
-            this.setState({checked: !checked});
-          }
-        }}
-        data-dash-is-loading={
-          (this.props.loading_state && this.props.loading_state.is_loading) ||
-          undefined
+  return (
+    <input
+      type="radio"
+      checked={checkedState}
+      {...omit(
+        ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
+        otherProps
+      )}
+      onClick={() => {
+        if (setProps) {
+          setProps({
+            checked: !checkedState
+          });
+        } else {
+          setCheckedState(!checkedState);
         }
-      />
-    );
-  }
-}
+      }}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    />
+  );
+};
 
 RadioButton.defaultProps = {
   persisted_props: ['checked'],

--- a/src/components/input/RadioButton.js
+++ b/src/components/input/RadioButton.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
@@ -7,25 +7,25 @@ import {omit} from 'ramda';
  */
 const RadioButton = props => {
   const {checked, loading_state, setProps, ...otherProps} = props;
-  const [checkedState, setCheckedState] = useState(checked);
-
-  useEffect(() => setCheckedState(checked), [checked]);
 
   return (
     <input
       type="radio"
-      checked={checkedState}
+      checked={checked}
       {...omit(
         ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
+      // really we're supposed to use onChange for updates, but it doesn't
+      // fire when a checked radio is clicked on, so we need to manage updates
+      // with onClick, but leaving onChange unspecified leads to unwanted
+      // warnings in the JavaScript console.
+      onChange={() => {}}
       onClick={() => {
         if (setProps) {
           setProps({
-            checked: !checkedState
+            checked: !checked
           });
-        } else {
-          setCheckedState(!checkedState);
         }
       }}
       data-dash-is-loading={
@@ -36,6 +36,7 @@ const RadioButton = props => {
 };
 
 RadioButton.defaultProps = {
+  checked: false,
   persisted_props: ['checked'],
   persistence_type: 'local'
 };

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -10,14 +10,10 @@ import CustomInput from '../../private/CustomInput';
  * Each radio item is rendered as an input and associated label which are
  * siblings of each other.
  */
-class RadioItems extends React.Component {
-  constructor(props) {
-    super(props);
+const RadioItems = props => {
+  const {id, className, style, options, key, loading_state} = props;
 
-    this.listItem = this.listItem.bind(this);
-  }
-
-  listItem(option) {
+  const listItem = option => {
     const {
       id,
       inputClassName,
@@ -31,7 +27,7 @@ class RadioItems extends React.Component {
       value,
       custom,
       switch: switches
-    } = this.props;
+    } = props;
 
     const checked = option.value === value;
 
@@ -100,28 +96,24 @@ class RadioItems extends React.Component {
         </div>
       );
     }
-  }
+  };
 
-  render() {
-    const {id, className, style, options, key, loading_state} = this.props;
+  const items = options.map(option => listItem(option));
 
-    const items = options.map(option => this.listItem(option));
-
-    return (
-      <div
-        id={id}
-        className={className}
-        style={style}
-        key={key}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {items}
-      </div>
-    );
-  }
-}
+  return (
+    <div
+      id={id}
+      className={className}
+      style={style}
+      key={key}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {items}
+    </div>
+  );
+};
 
 RadioItems.propTypes = {
   /**

--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {CustomInput} from 'reactstrap';
@@ -8,21 +8,11 @@ import {CustomInput} from 'reactstrap';
  * list of dictionaries with keys label, value and disabled.
  */
 const Select = props => {
-  const [value, setValue] = useState('');
-
   const handleChange = e => {
     if (props.setProps) {
       props.setProps({value: e.target.value});
-    } else {
-      setValue(e.target.value);
     }
   };
-
-  useEffect(() => {
-    if (props.value !== value) {
-      setValue(props.value || '');
-    }
-  }, [props.value]);
 
   return (
     <CustomInput
@@ -41,7 +31,7 @@ const Select = props => {
       )}
       type="select"
       onChange={handleChange}
-      value={value}
+      defaultValue={props.value}
       bsSize={props.bs_size}
     >
       <option value="" disabled hidden></option>
@@ -61,6 +51,7 @@ const Select = props => {
 };
 
 Select.defaultProps = {
+  value: '',
   persisted_props: ['value'],
   persistence_type: 'local'
 };

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classNames from 'classnames';

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -22,9 +22,6 @@ const Textarea = props => {
     loading_state,
     ...otherProps
   } = props;
-  const [valueState, setValueState] = useState(value);
-
-  useEffect(() => setValueState(value), [value]);
 
   const classes = classNames(
     className,
@@ -36,14 +33,12 @@ const Textarea = props => {
 
   return (
     <textarea
-      value={valueState}
+      defaultValue={value}
       className={classes}
       onChange={e => {
         const newValue = e.target.value;
         if (!debounce && setProps) {
           setProps({value: newValue});
-        } else {
-          setValueState(newValue);
         }
       }}
       onBlur={() => {
@@ -366,7 +361,8 @@ Textarea.defaultProps = {
   n_clicks_timestamp: -1,
   debounce: false,
   persisted_props: ['value'],
-  persistence_type: 'local'
+  persistence_type: 'local',
+  value: ''
 };
 
 export default Textarea;

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classNames from 'classnames';
@@ -7,107 +7,93 @@ import classNames from 'classnames';
  * A basic HTML textarea for entering multiline text based on the corresponding
  * component in dash-core-components
  */
-class Textarea extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {value: props.value};
-  }
+const Textarea = props => {
+  const {
+    value,
+    n_clicks,
+    n_blur,
+    n_submit,
+    setProps,
+    className,
+    invalid,
+    valid,
+    bs_size,
+    debounce,
+    loading_state,
+    ...otherProps
+  } = props;
+  const [valueState, setValueState] = useState(value);
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({value: nextProps.value});
-  }
+  useEffect(() => setValueState(value), [value]);
 
-  render() {
-    const {
-      setProps,
-      className,
-      invalid,
-      valid,
-      bs_size,
-      debounce,
-      loading_state
-    } = this.props;
-    const {value} = this.state;
+  const classes = classNames(
+    className,
+    invalid && 'is-invalid',
+    valid && 'is-valid',
+    bs_size ? `form-control-${bs_size}` : false,
+    'form-control'
+  );
 
-    const classes = classNames(
-      className,
-      invalid && 'is-invalid',
-      valid && 'is-valid',
-      bs_size ? `form-control-${bs_size}` : false,
-      'form-control'
-    );
-
-    return (
-      <textarea
-        value={value}
-        className={classes}
-        onChange={e => {
-          const newValue = e.target.value;
-          if (!debounce && setProps) {
-            setProps({value: newValue});
-          } else {
-            this.setState({value: newValue});
-          }
-        }}
-        onBlur={() => {
-          if (setProps) {
-            const payload = {
-              n_blur: this.props.n_blur + 1,
-              n_blur_timestamp: Date.now()
-            };
-            if (debounce) {
-              payload.value = value;
-            }
-            setProps(payload);
-          }
-        }}
-        onKeyPress={e => {
-          if (setProps && e.key === 'Enter') {
-            const payload = {
-              n_submit: this.props.n_submit + 1,
-              n_submit_timestamp: Date.now()
-            };
-            if (debounce) {
-              payload.value = value;
-            }
-            setProps(payload);
-          }
-        }}
-        onClick={() => {
-          if (setProps) {
-            setProps({
-              n_clicks: this.props.n_clicks + 1,
-              n_clicks_timestamp: Date.now()
-            });
-          }
-        }}
-        {...omit(
-          [
-            'setProps',
-            'value',
-            'valid',
-            'invalid',
-            'bs_size',
-            'className',
-            'n_blur',
-            'n_blur_timestamp',
-            'n_submit',
-            'n_submit_timestamp',
-            'debounce',
-            'loading_state',
-            'persistence',
-            'persistence_type',
-            'persisted_props'
-          ],
-          this.props
-        )}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
+  return (
+    <textarea
+      value={valueState}
+      className={classes}
+      onChange={e => {
+        const newValue = e.target.value;
+        if (!debounce && setProps) {
+          setProps({value: newValue});
+        } else {
+          setValueState(newValue);
         }
-      />
-    );
-  }
-}
+      }}
+      onBlur={() => {
+        if (setProps) {
+          const payload = {
+            n_blur: n_blur + 1,
+            n_blur_timestamp: Date.now()
+          };
+          if (debounce) {
+            payload.value = value;
+          }
+          setProps(payload);
+        }
+      }}
+      onKeyPress={e => {
+        if (setProps && e.key === 'Enter') {
+          const payload = {
+            n_submit: n_submit + 1,
+            n_submit_timestamp: Date.now()
+          };
+          if (debounce) {
+            payload.value = value;
+          }
+          setProps(payload);
+        }
+      }}
+      onClick={() => {
+        if (setProps) {
+          setProps({
+            n_clicks: n_clicks + 1,
+            n_clicks_timestamp: Date.now()
+          });
+        }
+      }}
+      {...omit(
+        [
+          'n_blur_timestamp',
+          'n_submit_timestamp',
+          'persistence',
+          'persistence_type',
+          'persisted_props'
+        ],
+        otherProps
+      )}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    />
+  );
+};
 
 Textarea.propTypes = {
   /**

--- a/src/components/input/__tests__/RadioButton.test.js
+++ b/src/components/input/__tests__/RadioButton.test.js
@@ -12,16 +12,17 @@ describe('RadioButton', () => {
     expect(radioButton).toHaveAttribute('type', 'radio');
   });
 
-  test('toggles checked value on click', () => {
+  test('passes checked prop on to underlying HTML element', () => {
     const {
-      container: {firstChild: radioButton}
+      container: {firstChild: radioButton},
+      rerender
     } = render(<RadioButton />);
     expect(radioButton.checked).toEqual(false);
 
-    userEvent.click(radioButton);
+    rerender(<RadioButton checked />);
     expect(radioButton.checked).toEqual(true);
 
-    userEvent.click(radioButton);
+    rerender(<RadioButton checked={false} />);
     expect(radioButton.checked).toEqual(false);
   });
 

--- a/src/components/input/__tests__/Textarea.test.js
+++ b/src/components/input/__tests__/Textarea.test.js
@@ -20,18 +20,6 @@ describe('Textarea', () => {
     expect(textarea).not.toHaveValue();
   });
 
-  test('passes value on to the underlying HTML textarea', () => {
-    const {
-      container: {firstChild: textarea},
-      rerender
-    } = render(<Textarea value="some-textarea-value" />);
-
-    expect(textarea).toHaveValue('some-textarea-value');
-
-    rerender(<Textarea value="another-textarea-value" />);
-    expect(textarea).toHaveValue('another-textarea-value');
-  });
-
   test('passes HTML attributes on to underlying textarea', () => {
     const {
       container: {firstChild: textarea}

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -7,40 +7,41 @@ import Link from '../../private/Link';
 /**
  * Create a single item in a `ListGroup`.
  */
-class ListGroupItem extends React.Component {
-  constructor(props) {
-    super(props);
+const ListGroupItem = props => {
+  let {
+    children,
+    loading_state,
+    target,
+    n_clicks,
+    setProps,
+    ...otherProps
+  } = props;
 
-    this.incrementClicks = this.incrementClicks.bind(this);
-  }
-
-  incrementClicks() {
-    if (!this.props.disabled && this.props.setProps) {
-      this.props.setProps({
-        n_clicks: this.props.n_clicks + 1,
+  const incrementClicks = () => {
+    if (!props.disabled && setProps) {
+      setProps({
+        n_clicks: n_clicks + 1,
         n_clicks_timestamp: Date.now()
       });
     }
-  }
+  };
 
-  render() {
-    let {children, loading_state, target, ...otherProps} = this.props;
-    const useLink = this.props.href && !this.props.disabled;
-    otherProps[useLink ? 'preOnClick' : 'onClick'] = this.incrementClicks;
-    return (
-      <RSListGroupItem
-        tag={useLink ? Link : 'li'}
-        target={useLink && target}
-        {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {children}
-      </RSListGroupItem>
-    );
-  }
-}
+  const useLink = props.href && !props.disabled;
+  otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
+
+  return (
+    <RSListGroupItem
+      tag={useLink ? Link : 'li'}
+      target={useLink && target}
+      {...omit(['n_clicks_timestamp'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {children}
+    </RSListGroupItem>
+  );
+};
 
 ListGroupItem.defaultProps = {
   n_clicks: 0,

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Modal as RSModal} from 'reactstrap';
@@ -7,43 +7,30 @@ import {Modal as RSModal} from 'reactstrap';
  * Create a toggleable dialog using the Modal component. Toggle the visibility
  * with the `is_open` prop.
  */
-class Modal extends React.Component {
-  constructor(props) {
-    super(props);
+const Modal = props => {
+  const {children, is_open, setProps, ...otherProps} = props;
+  const [modalOpen, setModalOpen] = useState(is_open);
 
-    this.toggle = this.toggle.bind(this);
-    this.state = {
-      modalOpen: props.is_open
-    };
-  }
-
-  toggle() {
-    if (this.props.setProps) {
-      this.props.setProps({is_open: !this.state.modalOpen});
-    } else {
-      this.setState({modalOpen: !this.state.modalOpen});
+  useEffect(() => {
+    if (is_open != modalOpen) {
+      setModalOpen(is_open);
     }
-  }
+  }, [is_open]);
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.is_open != prevState.modalOpen) {
-      return {modalOpen: nextProps.is_open};
-    } else return null;
-  }
+  const toggle = () => {
+    if (setProps) {
+      setProps({is_open: !modalOpen});
+    } else {
+      setModalOpen(!modalOpen);
+    }
+  };
 
-  render() {
-    const {children, ...otherProps} = this.props;
-    return (
-      <RSModal
-        isOpen={this.state.modalOpen}
-        toggle={this.toggle}
-        {...omit(['setProps', 'is_open'], otherProps)}
-      >
-        {children}
-      </RSModal>
-    );
-  }
-}
+  return (
+    <RSModal isOpen={modalOpen} toggle={toggle} {...otherProps}>
+      {children}
+    </RSModal>
+  );
+};
 
 Modal.propTypes = {
   /**

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,6 +1,5 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 import {Modal as RSModal} from 'reactstrap';
 
 /**
@@ -8,25 +7,23 @@ import {Modal as RSModal} from 'reactstrap';
  * with the `is_open` prop.
  */
 const Modal = props => {
-  const {children, is_open, setProps, ...otherProps} = props;
-  const [modalOpen, setModalOpen] = useState(is_open);
-
-  useEffect(() => {
-    if (is_open != modalOpen) {
-      setModalOpen(is_open);
-    }
-  }, [is_open]);
+  const {children, is_open, setProps, loading_state, ...otherProps} = props;
 
   const toggle = () => {
     if (setProps) {
-      setProps({is_open: !modalOpen});
-    } else {
-      setModalOpen(!modalOpen);
+      setProps({is_open: !is_open});
     }
   };
 
   return (
-    <RSModal isOpen={modalOpen} toggle={toggle} {...otherProps}>
+    <RSModal
+      isOpen={is_open}
+      toggle={toggle}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+      {...otherProps}
+    >
       {children}
     </RSModal>
   );
@@ -130,7 +127,25 @@ Modal.propTypes = {
   /**
    * Set the z-index of the modal. Default 1050.
    */
-  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default Modal;

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -8,48 +8,44 @@ import Link from '../../private/Link';
  * Add a link to a `Nav`. Can be used as a child of `NavItem` or of `Nav`
  * directly.
  */
-class NavLink extends React.Component {
-  constructor(props) {
-    super(props);
+const NavLink = props => {
+  const {
+    children,
+    disabled,
+    className,
+    active,
+    loading_state,
+    setProps,
+    n_clicks,
+    ...otherProps
+  } = props;
 
-    this.incrementClicks = this.incrementClicks.bind(this);
-  }
-
-  incrementClicks() {
-    if (!this.props.disabled && this.props.setProps) {
-      this.props.setProps({
-        n_clicks: this.props.n_clicks + 1,
+  const incrementClicks = () => {
+    if (!disabled && setProps) {
+      setProps({
+        n_clicks: n_clicks + 1,
         n_clicks_timestamp: Date.now()
       });
     }
-  }
+  };
 
-  render() {
-    const {
-      children,
-      className,
-      active,
-      loading_state,
-      ...otherProps
-    } = this.props;
-    const classes = classNames(className, 'nav-link', {
-      active,
-      disabled: otherProps.disabled
-    });
-    return (
-      <Link
-        className={classes}
-        preOnClick={this.incrementClicks}
-        {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        {children}
-      </Link>
-    );
-  }
-}
+  const classes = classNames(className, 'nav-link', {
+    active,
+    disabled: otherProps.disabled
+  });
+  return (
+    <Link
+      className={classes}
+      preOnClick={incrementClicks}
+      {...omit(['n_clicks_timestamp'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      {children}
+    </Link>
+  );
+};
 
 NavLink.defaultProps = {
   active: false,

--- a/src/components/nav/NavbarSimple.js
+++ b/src/components/nav/NavbarSimple.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import {Collapse, Container, Navbar as RSNavbar} from 'reactstrap';
@@ -23,67 +23,55 @@ const navbarColors = new Set([
  * A self-contained navbar ready for use. If you need more customisability try
  * `Navbar` instead.
  */
-class NavbarSimple extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: false
-    };
-    this.toggle = this.toggle.bind(this);
-  }
+const NavbarSimple = props => {
+  const {
+    children,
+    brand,
+    brand_href,
+    brand_style,
+    brand_external_link,
+    linksLeft,
+    fluid,
+    color,
+    style,
+    loading_state,
+    ...otherProps
+  } = props;
+  const isNavbarColor = navbarColors.has(color);
 
-  toggle() {
-    this.setState({
-      isOpen: !this.state.isOpen
-    });
-  }
+  const [navbarOpen, setNavbarOpen] = useState(false);
 
-  render() {
-    const {
-      children,
-      brand,
-      brand_href,
-      brand_style,
-      brand_external_link,
-      linksLeft,
-      fluid,
-      color,
-      style,
-      loading_state,
-      ...otherProps
-    } = this.props;
-    const isNavbarColor = navbarColors.has(color);
+  const toggle = () => setNavbarOpen(!navbarOpen);
 
-    return (
-      <RSNavbar
-        color={isNavbarColor ? color : null}
-        style={!isNavbarColor ? {backgroundColor: color, ...style} : style}
-        {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
-      >
-        <Container fluid={fluid}>
-          {brand && (
-            <NavbarBrand
-              href={brand_href}
-              style={brand_style}
-              external_link={brand_external_link}
-            >
-              {brand}
-            </NavbarBrand>
-          )}
-          <NavbarToggler onClick={this.toggle} />
-          <Collapse isOpen={this.state.isOpen} navbar>
-            <Nav className={linksLeft ? 'mr-auto' : 'ml-auto'} navbar>
-              {children}
-            </Nav>
-          </Collapse>
-        </Container>
-      </RSNavbar>
-    );
-  }
-}
+  return (
+    <RSNavbar
+      color={isNavbarColor ? color : null}
+      style={!isNavbarColor ? {backgroundColor: color, ...style} : style}
+      {...omit(['setProps'], otherProps)}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+    >
+      <Container fluid={fluid}>
+        {brand && (
+          <NavbarBrand
+            href={brand_href}
+            style={brand_style}
+            external_link={brand_external_link}
+          >
+            {brand}
+          </NavbarBrand>
+        )}
+        <NavbarToggler onClick={toggle} />
+        <Collapse isOpen={navbarOpen} navbar>
+          <Nav className={linksLeft ? 'mr-auto' : 'ml-auto'} navbar>
+            {children}
+          </Nav>
+        </Collapse>
+      </Container>
+    </RSNavbar>
+  );
+};
 
 NavbarSimple.defaultProps = {
   fluid: false,

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classnames from 'classnames';
@@ -51,26 +51,15 @@ const Tabs = props => {
   } = props;
   children = parseChildrenToArray(children);
 
-  const [activeTab, setActiveTab] = useState(
+  active_tab =
     active_tab !== undefined
       ? active_tab
-      : children && (resolveChildProps(children[0]).tab_id || 'tab-0')
-  );
-
-  useEffect(() => {
-    if (active_tab !== undefined) {
-      setActiveTab(active_tab);
-    }
-  }, [active_tab]);
+      : children && (resolveChildProps(children[0]).tab_id || 'tab-0');
 
   const toggle = tab => {
     if (setProps) {
       if (active_tab !== tab) {
         setProps({active_tab: tab});
-      }
-    } else {
-      if (activeTab !== tab) {
-        setActiveTab(tab);
       }
     }
   };
@@ -89,7 +78,7 @@ const Tabs = props => {
         >
           <NavLink
             className={classnames(childProps.labelClassName, {
-              active: activeTab === tabId
+              active: active_tab === tabId
             })}
             style={childProps.label_style}
             disabled={childProps.disabled}
@@ -148,7 +137,7 @@ const Tabs = props => {
       <Nav id={id} tabs card={card} className={className} style={style}>
         {links}
       </Nav>
-      <TabContent activeTab={activeTab}>{tabs}</TabContent>
+      <TabContent activeTab={active_tab}>{tabs}</TabContent>
     </div>
   );
 };


### PR DESCRIPTION
This PR refactors class components to functional components, which has a couple of benefits:

- Addresses warnings generated by deprecated lifecycle methods in class components like `componentWillReceiveProps` (see #391). More generally it should be a bit more future proof as this is the favoured pattern in React now.
- Smaller bundle size!

Along the way I also:
- Improved auto-dismissal of `Alert` and `Toast`. Previously when using the `duration` prop you could set the component to auto-dismiss after a fixed period of time. However, if you dismissed manually before the time was reached, the timer would not clear, hence if the component was toggled again it would auto-dismiss early.
- Made dismissal of `DropdownMenu` when clicking on a child `DropdownMenuItem` consistent.
