### PR TITLE
Fixed accordion in collapse example

### DIFF
--- a/docs/components_page/components/collapse/accordion.py
+++ b/docs/components_page/components/collapse/accordion.py
@@ -39,7 +39,7 @@ def toggle_accordion(n1, n2, n3, is_open1, is_open2, is_open3):
     ctx = dash.callback_context
 
     if not ctx.triggered:
-        return ['']*3
+        return False, False, False
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 

--- a/docs/components_page/components/collapse/accordion.py
+++ b/docs/components_page/components/collapse/accordion.py
@@ -39,7 +39,7 @@ def toggle_accordion(n1, n2, n3, is_open1, is_open2, is_open3):
     ctx = dash.callback_context
 
     if not ctx.triggered:
-        return ""
+        return list(""*3)
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 

--- a/docs/components_page/components/collapse/accordion.py
+++ b/docs/components_page/components/collapse/accordion.py
@@ -39,7 +39,7 @@ def toggle_accordion(n1, n2, n3, is_open1, is_open2, is_open3):
     ctx = dash.callback_context
 
     if not ctx.triggered:
-        return list(""*3)
+        return ['']*3
     else:
         button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 


### PR DESCRIPTION
This example doesn't work. As return statement required 3 values to be returned either in list or tuple.
So this will fix that problem.