### PR TITLE
Default tab fix

### DIFF
--- a/examples/advanced-component-usage/graphs_in_tabs.py
+++ b/examples/advanced-component-usage/graphs_in_tabs.py
@@ -60,7 +60,7 @@ def render_tab_content(active_tab, data):
                     dbc.Col(dcc.Graph(figure=data["hist_2"]), width=6),
                 ]
             )
-    return data
+    return "No tab selected"
 
 
 @app.callback(Output("store", "data"), [Input("button", "n_clicks")])

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classnames from 'classnames';
@@ -51,10 +51,15 @@ const Tabs = props => {
   } = props;
   children = parseChildrenToArray(children);
 
-  active_tab =
-    active_tab !== undefined
-      ? active_tab
-      : children && (resolveChildProps(children[0]).tab_id || 'tab-0');
+  // if active_tab not set initially, choose first tab
+  useEffect(() => {
+    if (setProps && active_tab === undefined) {
+      setProps({
+        active_tab:
+          children && (resolveChildProps(children[0]).tab_id || 'tab-0')
+      });
+    }
+  }, []);
 
   const toggle = tab => {
     if (setProps) {

--- a/src/components/tabs/__tests__/Tabs.test.js
+++ b/src/components/tabs/__tests__/Tabs.test.js
@@ -57,7 +57,7 @@ describe('Tabs', () => {
   test('tracks most recently clicked tab with "active_tab" prop', () => {
     const mockSetProps = jest.fn();
     const {container, getByText, rerender} = render(
-      <Tabs setProps={mockSetProps}>
+      <Tabs setProps={mockSetProps} active_tab="tab-0">
         <Tab label="tab-label-1">tab-content-1</Tab>
         <Tab label="tab-label-2">tab-content-2</Tab>
       </Tabs>


### PR DESCRIPTION
When using `Tabs`, if `active_tab` is initially unspecified the first tab is chosen for you as the default active tab. Previously however the `active_tab` prop was not updated to this default value, leading to an issue when using callbacks to dynamically render tab content. This PR adds a call to `setProps` on initialisation to make sure everything stays in sync.

It also updates the `graphs_in_tabs` example to ensure dictionaries are not passed to the children of a component.

Closes #404 