### PR TITLE
Temp docs fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-dash>=1.9.0
+dash==1.10.0
 dash_bootstrap_components==0.10.2
 gunicorn
 markdown


### PR DESCRIPTION
As observed in #407 the examples on the docs are currently not working. This appears to be due to a change in Dash 1.11.0, so while I investigate further I'm temporarily pinning to an earlier version of Dash.