### PR TITLE
Disabled link

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -15,6 +15,7 @@ import Link from '../private/Link';
 const Button = props => {
   const {
     children,
+    disabled,
     href,
     loading_state,
     setProps,
@@ -24,21 +25,22 @@ const Button = props => {
   } = props;
 
   const incrementClicks = () => {
-    if (!props.disabled && setProps) {
+    if (!disabled && setProps) {
       setProps({
         n_clicks: n_clicks + 1,
         n_clicks_timestamp: Date.now()
       });
     }
   };
-  const useLink = href && !props.disabled;
+  const useLink = href && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
 
   return (
     <RSButton
       tag={useLink ? Link : 'button'}
       target={useLink ? target : null}
-      href={props.disabled ? null : href}
+      href={disabled ? null : href}
+      disabled={disabled}
       {...omit(['n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from '@testing-library/react';
-import userEvent from '@testing-library/user-event'
+import userEvent from '@testing-library/user-event';
 import Button from '../Button';
 
 describe('Button', () => {
@@ -97,5 +97,20 @@ describe('Button', () => {
 
     expect(mockSetProps.mock.calls).toHaveLength(1);
     expect(mockSetProps.mock.calls[0][0].n_clicks).toBe(1);
+  });
+
+  test("doesn't track clicks if disabled", () => {
+    const mockSetProps = jest.fn();
+    const button = render(
+      <Button disabled setProps={mockSetProps}>
+        Clickable
+      </Button>
+    );
+
+    expect(mockSetProps.mock.calls).toHaveLength(0);
+
+    userEvent.click(button.getByText('Clickable'));
+
+    expect(mockSetProps.mock.calls).toHaveLength(0);
   });
 });

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -9,10 +9,10 @@ import Link from '../../private/Link';
  * used like buttons, external links, or internal Dash style links.
  */
 const CardLink = props => {
-  const {children, loading_state, ...otherProps} = props;
+  const {children, loading_state, disabled, ...otherProps} = props;
 
   const incrementClicks = () => {
-    if (!props.disabled && props.setProps) {
+    if (!disabled && props.setProps) {
       props.setProps({
         n_clicks: props.n_clicks + 1,
         n_clicks_timestamp: Date.now()
@@ -27,6 +27,7 @@ const CardLink = props => {
       }
       tag={Link}
       preOnClick={incrementClicks}
+      disabled={disabled}
       {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
     >
       {children}

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -47,6 +47,7 @@ const DropdownMenuItem = props => {
       // don't pass href if disabled otherwise reactstrap renders item
       // as link and the cursor becomes a pointer on hover
       href={disabled ? null : href}
+      disabled={disabled}
       target={useLink && target}
       {...omit(['setProps'], otherProps)}
       data-dash-is-loading={

--- a/src/components/dropdownmenu/__tests__/DropdownMenuItem.test.js
+++ b/src/components/dropdownmenu/__tests__/DropdownMenuItem.test.js
@@ -64,6 +64,8 @@ describe('DropdownMenuItem', () => {
       </DropdownMenu>
     );
 
+    expect(dropdownMenuItem.getByText('Clickable')).toHaveClass('disabled');
+
     expect(mockSetProps.mock.calls).toHaveLength(0);
 
     userEvent.click(dropdownMenuItem.getByText('Clickable'));

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -10,6 +10,7 @@ import Link from '../../private/Link';
 const ListGroupItem = props => {
   let {
     children,
+    disabled,
     loading_state,
     target,
     n_clicks,
@@ -18,7 +19,7 @@ const ListGroupItem = props => {
   } = props;
 
   const incrementClicks = () => {
-    if (!props.disabled && setProps) {
+    if (!disabled && setProps) {
       setProps({
         n_clicks: n_clicks + 1,
         n_clicks_timestamp: Date.now()
@@ -26,13 +27,14 @@ const ListGroupItem = props => {
     }
   };
 
-  const useLink = props.href && !props.disabled;
+  const useLink = props.href && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
 
   return (
     <RSListGroupItem
       tag={useLink ? Link : 'li'}
       target={useLink && target}
+      disabled={disabled}
       {...omit(['n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined

--- a/src/components/listgroup/__tests__/ListGroupItem.test.js
+++ b/src/components/listgroup/__tests__/ListGroupItem.test.js
@@ -61,4 +61,21 @@ describe('ListGroupItem', () => {
     expect(mockSetProps.mock.calls).toHaveLength(1);
     expect(mockSetProps.mock.calls[0][0].n_clicks).toBe(1);
   });
+
+  test("doesn't track clicks if disabled", () => {
+    const mockSetProps = jest.fn();
+    const listGroupItem = render(
+      <ListGroupItem disabled setProps={mockSetProps}>
+        Clickable
+      </ListGroupItem>
+    );
+
+    expect(listGroupItem.getByText('Clickable')).toHaveClass('disabled');
+
+    expect(mockSetProps.mock.calls).toHaveLength(0);
+
+    userEvent.click(listGroupItem.getByText('Clickable'));
+
+    expect(mockSetProps.mock.calls).toHaveLength(0);
+  });
 });

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -29,13 +29,11 @@ const NavLink = props => {
     }
   };
 
-  const classes = classNames(className, 'nav-link', {
-    active,
-    disabled: otherProps.disabled
-  });
+  const classes = classNames(className, 'nav-link', {active, disabled});
   return (
     <Link
       className={classes}
+      disabled={disabled}
       preOnClick={incrementClicks}
       {...omit(['n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={

--- a/src/components/nav/__tests__/NavLink.test.js
+++ b/src/components/nav/__tests__/NavLink.test.js
@@ -53,6 +53,7 @@ describe('NavLink', () => {
         Clickable
       </NavLink>
     );
+    expect(navLink.getByText('Clickable')).toHaveClass('disabled');
 
     expect(mockSetProps.mock.calls).toHaveLength(0);
 


### PR DESCRIPTION
Ensure link components can be disabled and increase test coverage to ensure regression doesn't slip through again.

Reported for `NavLink` in #409 