### PR TITLE
Persist null values in numeric input

### DIFF
--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -50,7 +50,7 @@ const Input = props => {
     if (props.type === 'number') {
       const convertedValue = convert(value);
       if (isNaN(convertedValue)) {
-        return;
+        return null;
       } else return convertedValue;
     } else return value;
   };

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -236,7 +236,7 @@ describe('Input', () => {
 
       const [call1, call2, call3] = mockSetProps.mock.calls;
       expect(call1).toEqual([{value: -1}]);
-      expect(call2).toEqual([{value: undefined}]);
+      expect(call2).toEqual([{value: null}]);
       expect(call3).toEqual([{value: -10000}]);
     });
 


### PR DESCRIPTION
Numeric input was calling `setProps` with `undefined` when input value was not valid, which in Dash should be reserved for uninitialised props and so was not being persisted. Returning `null` instead, which still gets interpreted as `None` in Python, but ensures that that value is persisted.

Reported in #283 