### PR TITLE
Serve Javascript bundle over unpkg CDN

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -17,6 +17,10 @@ _js_dist = [
         "relative_package_path": (
             "_components/dash_bootstrap_components.min.js"
         ),
+        "external_url": (
+            "https://unpkg.com/dash-bootstrap-components@{}"
+            "/dist/dash_bootstrap_components.min.js"
+        ).format(__version__),
         "namespace": "dash_bootstrap_components",
     }
 ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,17 @@ function cleanLib() {
   return del(['lib/*']);
 }
 
+function cleanDist() {
+  mkdirp.sync('dist');
+  return del(['dist/*']);
+}
+
+function copyDist() {
+  return src(
+    'dash_bootstrap_components/_components/dash_bootstrap_components.min.js'
+  ).pipe(dest('dist/'));
+}
+
 function cleanComponents() {
   return del(['dash_bootstrap_components/_components/*']);
 }
@@ -49,9 +60,15 @@ function addThemesToRNamespace() {
     .pipe(dest('.', {overwrite: true}));
 }
 
-exports.postPyBuild = series(copyGeneratedFiles, cleanGeneratedFiles);
-exports.clean = parallel(cleanGeneratedFiles, cleanComponents, cleanLib);
+exports.postPyBuild = series(copyDist, copyGeneratedFiles, cleanGeneratedFiles);
+exports.clean = parallel(
+  cleanGeneratedFiles,
+  cleanComponents,
+  cleanLib,
+  cleanDist
+);
 exports.postRBuild = series(
+  copyDist,
   copyGeneratedFiles,
   cleanGeneratedFiles,
   addThemesToRNamespace

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:watch": "jest --watch"
   },
   "files": [
+    "dist/dash_bootstrap_components.min.js",
     "lib",
     "src",
     "LICENSE.txt",

--- a/webpack/config.lib.js
+++ b/webpack/config.lib.js
@@ -11,7 +11,6 @@ var NODE_ENV = process.env.NODE_ENV || 'development';
 var environment = JSON.stringify(NODE_ENV);
 
 var LIBRARY_NAME = 'dash-bootstrap-components';
-var BUILD_PATH = path.join(directories.ROOT, LIBRARY_NAME, '_components');
 
 /* eslint-disable no-console */
 console.log('Current environment: ' + environment);


### PR DESCRIPTION
unpkg will host the Javascript bundle over CDN for free. We just need to make sure it's part of the distribution uploaded to npm.