### PR TITLE
Set version to 0.10.7-rc1

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -7,7 +7,7 @@ from . import _components
 from ._components import *  # noqa
 from ._table import _generate_table_from_df
 
-__version__ = "0.10.7-dev"
+__version__ = "0.10.7-rc1"
 _current_path = os.path.dirname(os.path.abspath(__file__))
 
 METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.10.7-dev",
+  "version": "0.10.7-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.10.7-dev"
+    assert __version__ == "0.10.7-rc1"


### PR DESCRIPTION
### Fixed

- Follow link as external link when `external_link=True` in `DropdownMenuItem` ([PR  458](https://github.com/facultyai/dash-bootstrap-components/pull/458))