### PR TITLE
Serve dash-bootstrap-components locally in development mode

### DIFF
--- a/docs/components_page/__init__.py
+++ b/docs/components_page/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import dash
@@ -8,6 +9,8 @@ from jinja2 import Environment, FileSystemLoader
 from .components.table.simple import table_body, table_header
 from .components.tabs.simple import tab1_content, tab2_content
 from .markdown_parser import parse
+
+SERVE_LOCALLY = os.getenv("DBC_DOCS_MODE", "production") == "dev"
 
 HERE = Path(__file__).parent
 COMPONENTS = HERE / "components"
@@ -130,7 +133,7 @@ def register_apps():
             external_stylesheets=["/static/loading.css"],
             requests_pathname_prefix=f"/docs/components/{slug}/",
             suppress_callback_exceptions=True,
-            serve_locally=False,
+            serve_locally=SERVE_LOCALLY,
             index_string=template.render(
                 sidenav_items=sidenav_items,
                 sidenav_active="components",

--- a/docs/examples/__init__.py
+++ b/docs/examples/__init__.py
@@ -9,6 +9,8 @@ from jinja2 import Environment, FileSystemLoader
 from .vendor.graphs_in_tabs import app as git_app
 from .vendor.iris import app as iris_app
 
+SERVE_LOCALLY = os.getenv("DBC_DOCS_MODE", "production") == "dev"
+
 HREF_PATTERN = re.compile(r'href="')
 
 HERE = Path(__file__).parent
@@ -73,7 +75,7 @@ def build_app_from_example(app, name, code, code_link, show_warning=False):
     new_app = dash.Dash(
         external_stylesheets=["/static/loading.css", dbc.themes.BOOTSTRAP],
         requests_pathname_prefix=f"/examples/{name}/",
-        serve_locally=False,
+        serve_locally=SERVE_LOCALLY,
         index_string=template.replace("<CODE>", code),
         update_title=None,
     )

--- a/docs/run.py
+++ b/docs/run.py
@@ -16,6 +16,9 @@ application = DispatcherMiddleware(
 )
 
 if __name__ == "__main__":
+    import os
+
     from werkzeug.serving import run_simple
 
+    os.environ["DBC_DOCS_MODE"] = "dev"
     run_simple("localhost", 8888, application, use_reloader=True)


### PR DESCRIPTION
The docs try to load the Dash component modules over a CDN to take advantage of browser caching when navigating between pages. This breaks development however, because the CDN link generated from the development version number of dash-bootstrap-components is invalid.

This fix ensures that bundles are served locally when running `python docs/run.py`, but will still be loaded over CDN in production (where we run `gunicorn run` from the docs directory).