### PR TITLE
Use Bootstrap 4.5.2

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -1,12 +1,12 @@
 .prependBootswatch <- function(suffix) {
-  BOOTSWATCH_BASE <- "https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/"
+  BOOTSWATCH_BASE <- "https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/"
   return(paste(BOOTSWATCH_BASE, suffix, sep=""))
 }
 
 #' @export'
 dbcThemes <- list(
-  BOOTSTRAP = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css",
-  GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap-grid.min.css",
+  BOOTSTRAP = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css",
+  GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap-grid.min.css",
   CERULEAN = .prependBootswatch("cerulean/bootstrap.min.css"),
   COSMO = .prependBootswatch("cosmo/bootstrap.min.css"),
   CYBORG = .prependBootswatch("cyborg/bootstrap.min.css"),

--- a/dash_bootstrap_components/themes.py
+++ b/dash_bootstrap_components/themes.py
@@ -1,10 +1,10 @@
 BOOTSTRAP = (
-    "https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+    "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
 )
 
-GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap-grid.min.css"  # noqa
+GRID = "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap-grid.min.css"  # noqa
 
-_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.5.0/"
+_BOOTSWATCH_BASE = "https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/"
 
 CERULEAN = _BOOTSWATCH_BASE + "cerulean/bootstrap.min.css"
 COSMO = _BOOTSWATCH_BASE + "cosmo/bootstrap.min.css"

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-      integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+      integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2"
       crossorigin="anonymous"
     />
   </head>

--- a/docs/templates/partials/head.html
+++ b/docs/templates/partials/head.html
@@ -2,7 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link
   rel="stylesheet"
-  href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+  href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
 />
 <link
   rel="stylesheet"


### PR DESCRIPTION
Update `themes` submodule and docs to use Bootstrap 4.5.2.

4.5.3 is the latest, but unavailable on bootstrapcdn for some reason.