### PR TITLE
Active NavLinks

### DIFF
--- a/docs/components_page/components/nav.md
+++ b/docs/components_page/components/nav.md
@@ -33,7 +33,7 @@ Use the `vertical` argument to stack navigation items. You can pass either a Boo
 
 ## Pills
 
-Use the `pills` argument to indicate active state with pill styled nav items.
+Use the `pills` argument to indicate active state with pill styled nav items. The `active` property can be set to `True` or `False` to manually control whether the link is active, or to `"exact"` to automatically set the `active` property when the current pathname matches the `href`, or to `"partial"` to automatically set the `active` property when the current pathname starts with `href`.
 
 {{example:components/nav/pill.py:nav}}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.10.8-rc2",
+  "version": "0.10.8-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3349,6 +3349,11 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@plotly/dash-component-plugins": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@plotly/dash-component-plugins/-/dash-component-plugins-1.2.0.tgz",
+      "integrity": "sha512-HnDyE5b1oh5l6vkZ/cd1Z/b7E4GeANLTMEeDom4WIeBYcJ/fH2PBAytZzgHXNsDYDJrMRPgfyiC7Y7jBIW4edA=="
     },
     "@testing-library/dom": {
       "version": "7.22.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@plotly/dash-component-plugins": "^1.2.0",
     "classnames": "^2.2.6",
     "fast-isnumeric": "^1.1.3",
     "is-absolute-url": "^2.1.0",

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -112,8 +112,10 @@ NavLink.propTypes = {
 
   /**
    * Apply 'active' style to this component. Set to "exact" to automatically
-   * toggle active status when pathname matches href, or to "partial" to
-   * automatically toggle on a partial match.
+   * toggle active status when the current pathname matches href, or to
+   * "partial" to automatically toggle on a partial match. Assumes that href is
+   * a relative url such as /link rather than an absolute such as
+   * https://example.com/link
    *
    * For example
    * - dbc.NavLink(..., href="/my-page", active="exact") will be active on

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classNames from 'classnames';
+import {History} from '@plotly/dash-component-plugins';
 import Link from '../../private/Link';
 
 /**
@@ -9,6 +10,7 @@ import Link from '../../private/Link';
  * directly.
  */
 const NavLink = props => {
+  const [linkActive, setLinkActive] = useState(false);
   const {
     children,
     disabled,
@@ -17,8 +19,17 @@ const NavLink = props => {
     loading_state,
     setProps,
     n_clicks,
+    href,
     ...otherProps
   } = props;
+
+  const pathnameToActive = pathname => {
+    setLinkActive(
+      active === true ||
+        (active === 'exact' && pathname === href) ||
+        (active === 'partial' && pathname.startsWith(href))
+    );
+  };
 
   const incrementClicks = () => {
     if (!disabled && setProps) {
@@ -29,12 +40,24 @@ const NavLink = props => {
     }
   };
 
-  const classes = classNames(className, 'nav-link', {active, disabled});
+  useEffect(() => {
+    // get initial pathname
+    pathnameToActive(window.location.pathname);
+
+    // add event listener to update on change
+    History.onChange(() => pathnameToActive(window.location.pathname));
+  }, []);
+
+  const classes = classNames(className, 'nav-link', {
+    active: linkActive,
+    disabled
+  });
   return (
     <Link
       className={classes}
       disabled={disabled}
       preOnClick={incrementClicks}
+      href={href}
       {...omit(['n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
@@ -88,9 +111,20 @@ NavLink.propTypes = {
   href: PropTypes.string,
 
   /**
-   * Apply 'active' style to this component
+   * Apply 'active' style to this component. Set to "exact" to automatically
+   * toggle active status when pathname matches href, or to "partial" to
+   * automatically toggle on a partial match.
+   *
+   * For example
+   * - dbc.NavLink(..., href="/my-page", active="exact") will be active on
+   *   "/my-page" but not "/my-page/other" or "/random"
+   * - dbc.NavLink(..., href="/my-page", active="partial") will be active on
+   *   "/my-page" and "/my-page/other" but not "/random"
    */
-  active: PropTypes.bool,
+  active: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf(['partial', 'exact'])
+  ]),
 
   /**
    * Disable the link


### PR DESCRIPTION
This PR enables `NavLink` to automatically detect `active` state based on the current URL. `active` can still be set to `True` or `False` to manually control whether the `NavLink` shows as active or not, or can be set to either `"exact"` or `"partial"` with the following properties

 - If `active="exact"` then the `active` styling will be applied if the current pathname exactly matches the `href` of the `NavLink`. For example, `dbc.NavLink(..., href="/my-page")` will automatically be active on `/my-page` but on no other page.
- If `active="partial"` then the `active` styling will be applied if the current pathname starts with the `href` of the `NavLink`. For example, `dbc.NavLink(..., href="/pets")` is active on `/pets`, `/pets/dogs`, `/pets/cats` etc., but not on `/random`.