### PR TITLE
Don't auto-deploy docs on file change

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,14 +1,6 @@
 name: Build docs
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - docs/**
-      - examples/**
-      - .github/workflows/build-docs.yml
-      - .github/actions/push_docs/**
   release:
     types:
       - released

--- a/tasks.py
+++ b/tasks.py
@@ -85,6 +85,21 @@ def copy_examples(ctx):
     )
 
 
+@task(copy_examples)
+def documentation(ctx):
+    """
+    Push documentation to Heroku
+    """
+    info("Deploying docs")
+    run("git checkout -b inv-push-docs")
+    run("git add docs/examples/vendor/*.py -f")
+    run('git commit -m "Add examples" --allow-empty')
+    run("git subtree split --prefix docs -b docs-deploy")
+    run("git push -f origin docs-deploy")
+    run("git checkout master")
+    run("git branch -D inv-push-docs docs-deploy")
+
+
 @task(
     help={
         "version": "Version number to finalize. Must be "


### PR DESCRIPTION
With hindsight the automated deployment of docs is a bit inconvenient if you want to add documentation for as yet unreleased features.

Docs are still auto-deployed on a new release. Added the old invoke task back in to make manual deployment easier.