### PR TITLE
Prerelease 0.11.0-rc1

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -7,7 +7,7 @@ from . import _components
 from ._components import *  # noqa
 from ._table import _generate_table_from_df
 
-__version__ = "0.10.8-dev"
+__version__ = "0.11.0-rc1"
 _current_path = os.path.dirname(os.path.abspath(__file__))
 
 METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.10.8-dev",
+  "version": "0.11.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.10.8-dev"
+    assert __version__ == "0.11.0-rc1"


### PR DESCRIPTION
This is a release candidate for dash-bootstrap-components 0.11.0

### Added

- The `NavLink` component can now automatically set the `active` prop based on the current pathname. Set `active="exact"` to toggle set `active=True` if the `href` exactly matches the current pathname, or `active="partial"` to set `active=True` if the current pathname starts with `href`  ([PR  482](https://github.com/facultyai/dash-bootstrap-components/pull/482))
- `active_tab_style` and `activeTabClassName` props to `Tab` for styling active tabs ([PR  491](https://github.com/facultyai/dash-bootstrap-components/pull/491))
- Exposed `name` prop on input components so that they can be used more effectively in form submissions, and `action` and `method` props of `Form` so that `Form` can be used to post form submissions to a route on the backend ([PR  474](https://github.com/facultyai/dash-bootstrap-components/pull/474))
- Exposes `type` prop on `Button` ([PR  470](https://github.com/facultyai/dash-bootstrap-components/pull/470))

### Fixed

- Cursor becomes pointer when hovering on tabs ([PR 480](https://github.com/facultyai/dash-bootstrap-components/pull/480))
- Current position on page is preserved when using `Spinner` as a loading component ([PR  465](https://github.com/facultyai/dash-bootstrap-components/pull/465))

### Changed

- Updated BootstrapCDN links to use Bootstrap v4.5.2 ([PR  481](https://github.com/facultyai/dash-bootstrap-components/pull/481))