### PR TITLE
Release 0.11.1

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -7,7 +7,7 @@ from . import _components
 from ._components import *  # noqa
 from ._table import _generate_table_from_df
 
-__version__ = "0.11.1-dev"
+__version__ = "0.11.1"
 _current_path = os.path.dirname(os.path.abspath(__file__))
 
 METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -6,9 +6,14 @@ title: Changelog
 
 This page documents notable changes in dash-bootstrap-components releases.
 
-## 0.11.0 - 2020/12/13
 
-This is a release candidate for dash-bootstrap-components 0.11.0
+## 0.11.1 - 2020/12/20
+
+### Fixed
+
+- Fixes bug that prevented `active` property of `NavLink` from being correctly updated by callbacks ([PR 499](https://github.com/facultyai/dash-bootstrap-components/pull/499))
+
+## 0.11.0 - 2020/12/13
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.11.1-dev",
+  "version": "0.11.1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.1-dev"
+    assert __version__ == "0.11.1"


### PR DESCRIPTION
### Fixed

- Fixes bug that prevented `active` property of `NavLink` from being correctly updated by callbacks ([PR 499](https://github.com/facultyai/dash-bootstrap-components/pull/499))