### PR TITLE
Support multiple column levels

### DIFF
--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -101,7 +101,7 @@ def _generate_table_from_df(
             for level in range(1, n_levels + 1)
         ]
 
-        #  Go from header break positions to cell spans
+        # Go from header break positions to cell spans
         header_spans = [
             reversed(
                 [

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -78,7 +78,7 @@ def _generate_table_from_df(
         # Get the actual headers
         n_levels = df.columns.nlevels
         header_values = [
-            [val for val in df.columns.get_level_values(level)]
+            list(df.columns.get_level_values(level))
             for level in range(n_levels)
         ]
 

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -1,8 +1,9 @@
 from functools import reduce
-from itertools import accumulate, groupby
+from itertools import groupby
 from operator import add
 
 import dash_html_components as html
+from numpy import cumsum
 
 
 def _generate_table_from_df(
@@ -85,7 +86,7 @@ def _generate_table_from_df(
         # The positions of header changes for each level as an integer
         header_breaks = [
             list(
-                accumulate(
+                cumsum(
                     [
                         len(list(group))
                         for _, group in groupby(header_values[level])

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -71,7 +71,17 @@ def _generate_table_from_df(
         elif isinstance(header, dict):
             df = df.rename(columns=header)
         table = [
-            html.Thead(html.Tr(children=[html.Th(col) for col in df.columns]))
+            html.Thead(
+                [
+                    html.Tr(
+                        children=[
+                            html.Th(col)
+                            for col in df.columns.get_level_values(level)
+                        ]
+                    )
+                    for level in range(df.columns.nlevels)
+                ]
+            )
         ]
     else:
         table = []

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -92,7 +92,9 @@ def _generate_table_from_df(
     table.append(
         html.Tbody(
             [
-                html.Tr([html.Td(df.iloc[i][col]) for col in df.columns])
+                html.Tr(
+                    [html.Td(df.iloc[i, j]) for j in range(len(df.columns))]
+                )
                 for i in range(len(df))
             ]
         )

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -1,3 +1,5 @@
+from itertools import groupby
+
 import dash_html_components as html
 
 
@@ -75,8 +77,10 @@ def _generate_table_from_df(
                 [
                     html.Tr(
                         children=[
-                            html.Th(col)
-                            for col in df.columns.get_level_values(level)
+                            html.Th(col, colSpan=len(list(group)))
+                            for col, group in groupby(
+                                df.columns.get_level_values(level)
+                            )
                         ]
                     )
                     for level in range(df.columns.nlevels)

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -3,7 +3,13 @@ from itertools import groupby
 from operator import add
 
 import dash_html_components as html
-from numpy import cumsum
+
+
+def _accumulate(iterable):
+    total = 0
+    for val in iterable:
+        total += val
+        yield total
 
 
 def _generate_table_from_df(
@@ -86,7 +92,7 @@ def _generate_table_from_df(
         # The positions of header changes for each level as an integer
         header_breaks = [
             list(
-                cumsum(
+                _accumulate(
                     [
                         len(list(group))
                         for _, group in groupby(header_values[level])

--- a/dash_bootstrap_components/_table.py
+++ b/dash_bootstrap_components/_table.py
@@ -5,13 +5,6 @@ from operator import add
 import dash_html_components as html
 
 
-def _accumulate(iterable):
-    total = 0
-    for val in iterable:
-        total += val
-        yield total
-
-
 def _generate_table_from_df(
     cls,
     df,
@@ -89,17 +82,16 @@ def _generate_table_from_df(
             for level in range(n_levels)
         ]
 
+        # The sizes of consecutive header groups at each level
+        header_spans = [
+            [len(list(group)) for _, group in groupby(level_values)]
+            for level_values in header_values
+        ]
+
         # The positions of header changes for each level as an integer
         header_breaks = [
-            list(
-                _accumulate(
-                    [
-                        len(list(group))
-                        for _, group in groupby(header_values[level])
-                    ]
-                )
-            )
-            for level in range(n_levels)
+            [sum(level_spans[:i]) for i in range(1, len(level_spans) + 1)]
+            for level_spans in header_spans
         ]
 
         # Include breaks from higher levels
@@ -108,7 +100,7 @@ def _generate_table_from_df(
             for level in range(1, n_levels + 1)
         ]
 
-        # Go from header break positions to cell spans
+        # Go from header break positions back to cell spans
         header_spans = [
             reversed(
                 [


### PR DESCRIPTION
Renders pandas MultiLevel column titles in the Table component when generated from a DataFrame.

As asked for in https://github.com/facultyai/dash-bootstrap-components/issues/507