### PR TITLE
Prerelease 0.11.2-rc1

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -7,7 +7,7 @@ from . import _components
 from ._components import *  # noqa
 from ._table import _generate_table_from_df
 
-__version__ = "0.11.2-dev"
+__version__ = "0.11.2-rc1"
 _current_path = os.path.dirname(os.path.abspath(__file__))
 
 METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.11.2-dev",
+  "version": "0.11.2-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.2-dev"
+    assert __version__ == "0.11.2-rc1"


### PR DESCRIPTION
This is a release candidate for dash-bootstrap-components 0.11.2

### Added

- `color` prop for multiple components now accepts CSS colors, hex strings etc. ([PR  506](https://github.com/facultyai/dash-bootstrap-components/pull/506))
-  `Table.from_dataframe` now supports multiple column header levels ([PR  509](https://github.com/facultyai/dash-bootstrap-components/pull/509))