### PR TITLE
Release 0.11.3

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -7,7 +7,7 @@ from . import _components
 from ._components import *  # noqa
 from ._table import _generate_table_from_df
 
-__version__ = "0.11.3-dev"
+__version__ = "0.11.3"
 _current_path = os.path.dirname(os.path.abspath(__file__))
 
 METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -6,6 +6,10 @@ title: Changelog
 
 This page documents notable changes in dash-bootstrap-components releases.
 
+## 0.11.3 - 2021/2/13
+
+This version marks the first release of dash-bootstrap-components for Julia. There are no changes in functionality.
+
 ## 0.11.2 - 2021/2/5
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.11.3-dev",
+  "version": "0.11.3",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.3-dev"
+    assert __version__ == "0.11.3"


### PR DESCRIPTION
This version marks the first release of dash-bootstrap-components for Julia. There are no changes in functionality.