### PR TITLE
Add new  proptype to the popover: Trigger

### DIFF
--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -86,6 +86,11 @@ Popover.propTypes = {
    * Where to inject the popper DOM node, default body.
    */
   container: PropTypes.string,
+  
+  /**
+   * space separated list of triggers (e.g. "click hover focus").
+   */
+  trigger: PropTypes.string,
 
   /**
    * Whether the Popover is open or not.


### PR DESCRIPTION
I propose the adding of a new proptype called Trigger, neccesary for closing a popover outside of its box.