### PR TITLE
Prerelease 0.12.0-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.4-dev"
+__version__ = "0.12.0-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "0.11.4-dev",
+  "version": "0.12.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.4-dev"
+    assert __version__ == "0.12.0-rc1"


### PR DESCRIPTION
### Added

- Adds a new `trigger` property to `Popover`, allowing it to be used without writing callbacks if desired ([PR 531](https://github.com/facultyai/dash-bootstrap-components/pull/531))
- Exposes `download` prop on `Button` ([PR 528](https://github.com/facultyai/dash-bootstrap-components/pull/528))

### Fixed

- Restore default colours in `Alert` and `Badge` components ([PR 542](https://github.com/facultyai/dash-bootstrap-components/pull/542))

### Changed

- Adds `visibility:hidden` to `Fade` when content is faded so that tooltips do not appear on faded content ([PR 535](https://github.com/facultyai/dash-bootstrap-components/pull/535), [PR 537](https://github.com/facultyai/dash-bootstrap-components/pull/537))