### PR TITLE
Set default value of toggle correctly

### DIFF
--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -32,7 +32,7 @@ const Popover = props => {
       hideArrow={hide_arrow}
       // to ensure proper backwards compatibility, the toggle function is only
       // passed to the popover if `trigger` is not specified
-      toggle={trigger ? toggle : null}
+      toggle={trigger ? toggle : undefined}
       trigger={trigger}
       {...omit(['setProps'], otherProps)}
       data-dash-is-loading={


### PR DESCRIPTION
Use `undefined` instead of `null` so that the underlying reactstrap
component correctly sets the default value of toggle, and doesn't send
error messages to the console.
