### PR TITLE
Add name and value props to Button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -23,6 +23,8 @@ const Button = props => {
     target,
     type,
     download,
+    name,
+    value,
     ...otherProps
   } = props;
 
@@ -45,6 +47,8 @@ const Button = props => {
       href={disabled ? null : href}
       disabled={disabled}
       download={useLink ? download : null}
+      name={useLink ? null : name}
+      value={useLink ? null : value}
       {...omit(['n_clicks_timestamp'], otherProps)}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
@@ -193,7 +197,20 @@ Button.propTypes = {
   /**
    * Indicates that the hyperlink is to be used for downloading a resource.
    */
-  download: PropTypes.string
+  download: PropTypes.string,
+
+  /**
+   * The name of the button, submitted as a pair with the button’s value as part
+   * of the form data.
+   */
+  name: PropTypes.string,
+
+  /**
+   * Defines the value associated with the button’s name when it’s submitted
+   * with the form data. This value is passed to the server in params when the
+   * form is submitted.
+   */
+  value: PropTypes.string
 };
 
 export default Button;


### PR DESCRIPTION
As requested in #553 

Example usage:

```python
import dash
import dash_bootstrap_components as dbc
from flask import request

app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])

app.layout = dbc.Container(
    dbc.Form(
        [
            dbc.Input(name="input"),
            dbc.Button("Submit", name="submit", value="submitting"),
            dbc.Button("Submit alt", name="submit-alt", value="submitting-alt")
        ],
        method="POST",
        action="/test",
        id="form",
        prevent_default_on_submit=False,
    ),
    className="p-5",
)


@app.server.route("/test", methods=["POST"])
def test():
    return request.form


if __name__ == "__main__":
    app.run_server(debug=True)
```