### PR TITLE
Fix spinner_style prop of Spinner

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -59,7 +59,7 @@ const Spinner = props => {
     ...fullscreen_style
   };
 
-  const SpinnerDiv = style => (
+  const SpinnerDiv = ({style}) => (
     <RSSpinner
       color={isBootstrapColor ? color : null}
       style={{color: !isBootstrapColor && color, ...style}}
@@ -175,7 +175,7 @@ Spinner.propTypes = {
   type: PropTypes.string,
 
   /**
-   * The spinner size. Options are 'sm', 'md' and 'lg'.
+   * The spinner size. Options are 'sm', and 'md'.
    */
   size: PropTypes.string,
 

--- a/src/components/__tests__/Spinner.test.js
+++ b/src/components/__tests__/Spinner.test.js
@@ -61,12 +61,62 @@ describe('Spinner', () => {
     const {
       container: {firstChild: spinnerSm}
     } = render(<Spinner size="sm" />);
-    const {
-      container: {firstChild: spinnerLg}
-    } = render(<Spinner size="lg" />);
 
     expect(spinnerSm).toHaveClass('spinner-border-sm');
-    expect(spinnerLg).toHaveClass('spinner-border-lg');
+
+    // spinner styles
+    const {
+      container: {firstChild: spinnerStyle}
+    } = render(<Spinner spinner_style={{width: '5rem', height: '5rem'}} />);
+
+    expect(spinnerStyle).toHaveStyle({width: '5rem', height: '5rem'});
+  });
+
+  test('applies additional CSS classes when props are set and children are present', () => {
+    // grow spinner
+    const {
+      container: {
+        firstChild: {lastChild: spinner}
+      }
+    } = render(
+      <Spinner type="grow" loading_state={{is_loading: true}}>
+        <p>Child</p>
+      </Spinner>
+    );
+
+    expect(spinner.firstChild).toHaveClass('spinner-grow');
+
+    // spinner sizes
+    const {
+      container: {
+        firstChild: {lastChild: spinnerSm}
+      }
+    } = render(
+      <Spinner size="sm" loading_state={{is_loading: true}}>
+        <p>Child</p>
+      </Spinner>
+    );
+
+    expect(spinnerSm.firstChild).toHaveClass('spinner-border-sm');
+
+    // spinner styles
+    const {
+      container: {
+        firstChild: {lastChild: spinnerStyle}
+      }
+    } = render(
+      <Spinner
+        spinner_style={{width: '5rem', height: '5rem'}}
+        loading_state={{is_loading: true}}
+      >
+        <p>Child</p>
+      </Spinner>
+    );
+
+    expect(spinnerStyle.firstChild).toHaveStyle({
+      width: '5rem',
+      height: '5rem'
+    });
   });
 
   test('applies contextual colors with "color" prop', () => {


### PR DESCRIPTION
`spinner_style` prop was not being correctly passed to components, meaning it was not possible to e.g. adjust the size of the `Spinner`.

See #577 