### PR TITLE
Removed unused link in docs

### DIFF
--- a/docs/components_page/__init__.py
+++ b/docs/components_page/__init__.py
@@ -110,7 +110,6 @@ def register_apps():
         },
         {"name": "themes", "href": "/docs/themes", "label": "Themes"},
         {"name": "faq", "href": "/docs/faq", "label": "FAQ"},
-        {"name": "dashr", "href": "/docs/dashr", "label": "Dash for R"},
         {
             "name": "components",
             "href": "/docs/components",


### PR DESCRIPTION
Components page in docs had unused link to Dash for R.