### PR TITLE
Add bootstrap icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,10 @@ docs/examples/vendor
 # R build artifacts
 inst
 man
-R
+R/*
 DESCRIPTION
 NAMESPACE
+!R/icons.R
 !R/themes.R
 
 # Julia build artifacts

--- a/R/icons.R
+++ b/R/icons.R
@@ -1,0 +1,5 @@
+#' @export'
+dbcIcons <- list(
+  BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css",
+  FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"
+)

--- a/R/icons.R
+++ b/R/icons.R
@@ -1,5 +1,5 @@
 #' @export'
 dbcIcons <- list(
   BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css",
-  FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"
+  FONT_AWESOME = "https://use.fontawesome.com/releases/v5.15.4/css/all.css"
 )

--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-from dash_bootstrap_components import themes  # noqa
 from dash_bootstrap_components import icons  # noqa
+from dash_bootstrap_components import themes  # noqa
 from dash_bootstrap_components import _components
 from dash_bootstrap_components._components import *  # noqa
 from dash_bootstrap_components._table import _generate_table_from_df

--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from dash_bootstrap_components import themes  # noqa
+from dash_bootstrap_components import icons  # noqa
 from dash_bootstrap_components import _components
 from dash_bootstrap_components._components import *  # noqa
 from dash_bootstrap_components._table import _generate_table_from_df

--- a/dash_bootstrap_components/icons.py
+++ b/dash_bootstrap_components/icons.py
@@ -1,0 +1,2 @@
+BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"

--- a/dash_bootstrap_components/icons.py
+++ b/dash_bootstrap_components/icons.py
@@ -2,4 +2,4 @@ BOOTSTRAP = (
     "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/"
     "font/bootstrap-icons.css"
 )
-FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"
+FONT_AWESOME = "https://use.fontawesome.com/releases/v5.15.4/css/all.css"

--- a/dash_bootstrap_components/icons.py
+++ b/dash_bootstrap_components/icons.py
@@ -1,2 +1,5 @@
-BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+BOOTSTRAP = (
+    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/"
+    "font/bootstrap-icons.css"
+)
 FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"

--- a/docs/components_page/__init__.py
+++ b/docs/components_page/__init__.py
@@ -150,6 +150,7 @@ def register_apps():
             "label": "Quickstart",
         },
         {"name": "themes", "href": "/docs/themes", "label": "Themes"},
+        {"name": "icons", "href": "/docs/icons", "label": "Icons"},
         {"name": "faq", "href": "/docs/faq", "label": "FAQ"},
         {
             "name": "components",
@@ -173,7 +174,10 @@ def register_apps():
 
     for slug, kwargs in component_bodies.items():
         app = dash.Dash(
-            external_stylesheets=["/static/loading.css"],
+            external_stylesheets=[
+                "/static/loading.css",
+                dbc.icons.BOOTSTRAP,
+            ],
             requests_pathname_prefix=f"/docs/components/{slug}/",
             suppress_callback_exceptions=True,
             serve_locally=SERVE_LOCALLY,

--- a/docs/components_page/__init__.py
+++ b/docs/components_page/__init__.py
@@ -174,10 +174,7 @@ def register_apps():
 
     for slug, kwargs in component_bodies.items():
         app = dash.Dash(
-            external_stylesheets=[
-                "/static/loading.css",
-                dbc.icons.BOOTSTRAP,
-            ],
+            external_stylesheets=["/static/loading.css"],
             requests_pathname_prefix=f"/docs/components/{slug}/",
             suppress_callback_exceptions=True,
             serve_locally=SERVE_LOCALLY,

--- a/docs/components_page/components/alert.md
+++ b/docs/components_page/components/alert.md
@@ -33,10 +33,4 @@ You can have your `Alert` components dismiss themselves by using the `duration` 
 
 {{example:components/alert/auto_dismiss.py:alert}}
 
-## Icons
-
-You can additionally make use of the [Bootstrap Icon](/docs/icons) library to create alerts using icons.
-
-{{example:components/alert/icon.py:alerts}}
-
 {{apidoc:src/components/Alert.js}}

--- a/docs/components_page/components/alert.md
+++ b/docs/components_page/components/alert.md
@@ -33,4 +33,10 @@ You can have your `Alert` components dismiss themselves by using the `duration` 
 
 {{example:components/alert/auto_dismiss.py:alert}}
 
+## Icons
+
+You can additionally make use of the [Bootstrap Icon](/docs/icons) library to create alerts using icons.
+
+{{example:components/alert/icon.py:alerts}}
+
 {{apidoc:src/components/Alert.js}}

--- a/docs/components_page/components/alert/icon.R
+++ b/docs/components_page/components/alert/icon.R
@@ -1,0 +1,39 @@
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+alerts <- htmlDiv(
+    list(
+        dbcAlert(
+            list(
+                htmlI(class_name="bi bi-info-circle-fill me-2"),
+                "An example info alert with an icon"
+            ),
+            color="info",
+            class_name="d-flex align-items-center"
+        ),
+        dbcAlert(
+            list(
+                htmlI(class_name="bi bi-check-circle-fill me-2"),
+                "An example success alert with an icon"
+            ),
+            color="success",
+            class_name="d-flex align-items-center"
+        ),
+        dbcAlert(
+            list(
+                htmlI(class_name="bi bi-exclamation-triangle-fill me-2"),
+                "An example warning alert with an icon"
+            ),
+            color="warning",
+            class_name="d-flex align-items-center"
+        ),
+        dbcAlert(
+            list(
+                htmlI(class_name="bi bi-x-octagon-fill me-2"),
+                "An example danger alert with an icon"
+            ),
+            color="danger",
+            class_name="d-flex align-items-center"
+        )
+    )
+)

--- a/docs/components_page/components/alert/icon.R
+++ b/docs/components_page/components/alert/icon.R
@@ -2,38 +2,38 @@ library(dashBootstrapComponents)
 library(dashHtmlComponents)
 
 alerts <- htmlDiv(
-    list(
-        dbcAlert(
-            list(
-                htmlI(class_name="bi bi-info-circle-fill me-2"),
-                "An example info alert with an icon"
-            ),
-            color="info",
-            class_name="d-flex align-items-center"
-        ),
-        dbcAlert(
-            list(
-                htmlI(class_name="bi bi-check-circle-fill me-2"),
-                "An example success alert with an icon"
-            ),
-            color="success",
-            class_name="d-flex align-items-center"
-        ),
-        dbcAlert(
-            list(
-                htmlI(class_name="bi bi-exclamation-triangle-fill me-2"),
-                "An example warning alert with an icon"
-            ),
-            color="warning",
-            class_name="d-flex align-items-center"
-        ),
-        dbcAlert(
-            list(
-                htmlI(class_name="bi bi-x-octagon-fill me-2"),
-                "An example danger alert with an icon"
-            ),
-            color="danger",
-            class_name="d-flex align-items-center"
-        )
+  list(
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-info-circle-fill me-2"),
+        "An example info alert with an icon"
+      ),
+      color = "info",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-check-circle-fill me-2"),
+        "An example success alert with an icon"
+      ),
+      color = "success",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-exclamation-triangle-fill me-2"),
+        "An example warning alert with an icon"
+      ),
+      color = "warning",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-x-octagon-fill me-2"),
+        "An example danger alert with an icon"
+      ),
+      color = "danger",
+      class_name = "d-flex align-items-center"
     )
+  )
 )

--- a/docs/components_page/components/alert/icon.jl
+++ b/docs/components_page/components/alert/icon.jl
@@ -1,0 +1,38 @@
+using DashBootstrapComponents, DashHtmlComponents
+
+alerts = html_div(
+    [
+        dbc_alert(
+            [
+                html_i(class_name="bi bi-info-circle-fill me-2"),
+                "An example info alert with an icon",
+            ],
+            color="info",
+            class_name="d-flex align-items-center",
+        ),
+        dbc_alert(
+            [
+                html_i(class_name="bi bi-check-circle-fill me-2"),
+                "An example success alert with an icon",
+            ],
+            color="success",
+            class_name="d-flex align-items-center",
+        ),
+        dbc_alert(
+            [
+                html_i(class_name="bi bi-exclamation-triangle-fill me-2"),
+                "An example warning alert with an icon",
+            ],
+            color="warning",
+            class_name="d-flex align-items-center",
+        ),
+        dbc_alert(
+            [
+                html_i(class_name="bi bi-x-octagon-fill me-2"),
+                "An example danger alert with an icon",
+            ],
+            color="danger",
+            class_name="d-flex align-items-center",
+        ),
+    ]
+)

--- a/docs/components_page/components/alert/icon.jl
+++ b/docs/components_page/components/alert/icon.jl
@@ -1,38 +1,36 @@
 using DashBootstrapComponents, DashHtmlComponents
 
-alerts = html_div(
-    [
-        dbc_alert(
-            [
-                html_i(class_name="bi bi-info-circle-fill me-2"),
-                "An example info alert with an icon",
-            ],
-            color="info",
-            class_name="d-flex align-items-center",
-        ),
-        dbc_alert(
-            [
-                html_i(class_name="bi bi-check-circle-fill me-2"),
-                "An example success alert with an icon",
-            ],
-            color="success",
-            class_name="d-flex align-items-center",
-        ),
-        dbc_alert(
-            [
-                html_i(class_name="bi bi-exclamation-triangle-fill me-2"),
-                "An example warning alert with an icon",
-            ],
-            color="warning",
-            class_name="d-flex align-items-center",
-        ),
-        dbc_alert(
-            [
-                html_i(class_name="bi bi-x-octagon-fill me-2"),
-                "An example danger alert with an icon",
-            ],
-            color="danger",
-            class_name="d-flex align-items-center",
-        ),
-    ]
-)
+alerts = html_div([
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-info-circle-fill me-2"),
+            "An example info alert with an icon",
+        ],
+        color = "info",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-check-circle-fill me-2"),
+            "An example success alert with an icon",
+        ],
+        color = "success",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-exclamation-triangle-fill me-2"),
+            "An example warning alert with an icon",
+        ],
+        color = "warning",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-x-octagon-fill me-2"),
+            "An example danger alert with an icon",
+        ],
+        color = "danger",
+        class_name = "d-flex align-items-center",
+    ),
+])

--- a/docs/components_page/components/alert/icon.py
+++ b/docs/components_page/components/alert/icon.py
@@ -1,0 +1,39 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+alerts = html.Div(
+    [
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-info-circle-fill me-2"),
+                "An example info alert with an icon",
+            ],
+            color="info",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-check-circle-fill me-2"),
+                "An example success alert with an icon",
+            ],
+            color="success",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-exclamation-triangle-fill me-2"),
+                "An example warning alert with an icon",
+            ],
+            color="warning",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-x-octagon-fill me-2"),
+                "An example danger alert with an icon",
+            ],
+            color="danger",
+            class_name="d-flex align-items-center",
+        ),
+    ]
+)

--- a/docs/content/docs/icons.md
+++ b/docs/content/docs/icons.md
@@ -1,0 +1,55 @@
+---
+title: Icons
+---
+
+# Icons
+
+<p class="lead">Add Bootstrap Icons to enhance your application.</p>
+
+As with the [CSS stylesheets](/docs/themes), _dash-bootstrap-components_ doesn't come with specific icon CSS included. This is to give you the freedom to use any icon library of your choice.
+
+There are a number of different icon libraries available, which you can link to via CDN, or served locally depending on your needs. Details on how to link css can be found in the [Themes](/docs/themes) section.
+
+## Packaged CDN links
+
+Bootstrap have their own set of icons for use alongside their other components. There is excellent documentation on how to use them on the [Bootstrap website](https://icons.getbootstrap.com/#usage), and an example of them in use within Dash can be found in the [`alert` component](/docs/components/alert).
+
+_dash-bootstrap-components_ contains a link to Bootstrap Icons so you can conveniently link to them in your app. The easiest way to do so is to use the `external_stylesheets` argument when instantiating your app.
+
+In addition, we have included Bootstrap recommend icon package [Font Awesome](https://fontawesome.com/) (`icons.FONT_AWESOME`) to provide additional icons.
+
+~~~bootstrap-tabs
+Python
+
+Links are available in the `dash_bootstrap_components.icons` submodule.
+
+```python
+import dash
+import dash_bootstrap_components as dbc
+
+app = dash.Dash(external_stylesheets=[dbc.icons.BOOTSTRAP])
+```
+-----
+R
+
+Links are available in the `dbcIcons` list which is added to your namespace when you import `dashBootstrapComponents`.
+
+```r
+library(dash)
+library(dashBootstrapComponents)
+
+app <- Dash$new(external_stylesheets = dbcIcons$BOOTSTRAP)
+```
+
+-----
+Julia
+
+Links are available as part of the `dbc_icons` named tuple available in `DashBootstrapComponents`.
+
+```julia
+using Dash, DashBootstrapComponents
+
+app = dash(external_stylesheets=[dbc_icons.BOOTSTRAP])
+```
+
+~~~

--- a/docs/content/docs/icons.md
+++ b/docs/content/docs/icons.md
@@ -4,19 +4,19 @@ title: Icons
 
 # Icons
 
-<p class="lead">Add Bootstrap Icons to enhance your application.</p>
+<p class="lead">Add icons to enhance your application.</p>
 
-As with the [CSS stylesheets](/docs/themes), _dash-bootstrap-components_ doesn't come with specific icon CSS included. This is to give you the freedom to use any icon library of your choice.
+As with the [CSS stylesheets](/docs/themes), _dash-bootstrap-components_ doesn't come pre-bundled with icons. This is to give you the freedom to use any icon library of your choice.
 
-There are a number of different icon libraries available, which you can link to via CDN, or served locally depending on your needs. Details on how to link css can be found in the [Themes](/docs/themes) section.
+There are a number of different icon libraries available, which you can link to via CDN, or serve locally depending on your needs. Details on how to link css can be found in the [themes](/docs/themes) documentation.
 
 ## Packaged CDN links
 
-Bootstrap have their own set of icons for use alongside their other components. There is excellent documentation on how to use them on the [Bootstrap website](https://icons.getbootstrap.com/#usage), and an example of them in use within Dash can be found in the [`alert` component](/docs/components/alert).
+_dash-bootstrap-components_ contains CDN links for [Bootstrap Icons](https://icons.getbootstrap.com/) and [Font Awesome](https://fontawesome.com/), two libraries of icons you can use in your apps. You can use either of them by adding them to `external_stylesheets` when instantiating your app.
 
-_dash-bootstrap-components_ contains a link to Bootstrap Icons so you can conveniently link to them in your app. The easiest way to do so is to use the `external_stylesheets` argument when instantiating your app.
+Bootstrap Icons was developed by the Bootstrap team specifically for use with Bootstrap. There is excellent documentation on how to use them on the [Bootstrap website](https://icons.getbootstrap.com/#usage), and a small example below.
 
-In addition, we have included Bootstrap recommend icon package [Font Awesome](https://fontawesome.com/) (`icons.FONT_AWESOME`) to provide additional icons.
+Font Awesome is perhaps the most widely used icon library and is very commonly used with Bootstrap. Usage is similar to Bootstrap Icons, check [their documentation](https://fontawesome.com/v5.15/how-to-use/on-the-web/referencing-icons/basic-use) for more details.
 
 ~~~bootstrap-tabs
 Python
@@ -27,7 +27,15 @@ Links are available in the `dash_bootstrap_components.icons` submodule.
 import dash
 import dash_bootstrap_components as dbc
 
-app = dash.Dash(external_stylesheets=[dbc.icons.BOOTSTRAP])
+# For Bootstrap Icons...
+app = dash.Dash(
+    external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.BOOTSTRAP]
+)
+# Or for Font Awesome Icons...
+app = dash.Dash(
+    external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.FONT_AWESOME]
+)
+
 ```
 -----
 R
@@ -38,7 +46,14 @@ Links are available in the `dbcIcons` list which is added to your namespace when
 library(dash)
 library(dashBootstrapComponents)
 
-app <- Dash$new(external_stylesheets = dbcIcons$BOOTSTRAP)
+# For Bootstrap Icons...
+app <- Dash$new(
+    external_stylesheets = list(dbcThemes$BOOTSTRAP, dbcIcons$BOOTSTRAP)
+)
+# Or for Font Awesome Icons...
+app <- Dash$new(
+    external_stylesheets = list(dbcThemes$BOOTSTRAP, dbcIcons$FONT_AWESOME)
+)
 ```
 
 -----
@@ -49,7 +64,168 @@ Links are available as part of the `dbc_icons` named tuple available in `DashBoo
 ```julia
 using Dash, DashBootstrapComponents
 
-app = dash(external_stylesheets=[dbc_icons.BOOTSTRAP])
+# For Bootstrap Icons...
+app = dash(
+    external_stylesheets=[dbc_themes.BOOTSTRAP, dbc_icons.BOOTSTRAP]
+)
+# Or for Font Awesome Icons...
+app = dash(
+    external_stylesheets=[dbc_themes.BOOTSTRAP, dbc_icons.FONT_AWESOME]
+)
+```
+~~~
+
+## Example
+
+This simple example adds Bootstrap Icons to some alerts.
+
+~~~bootstrap-example-tabs
+<div>
+    <div class="alert alert-info d-flex align-items-center">
+    <i class="bi bi-info-circle-fill me-2"></i>
+    An example info alert with an icon
+    </div>
+    <div class="alert alert-success d-flex align-items-center">
+    <i class="bi bi-check-circle-fill me-2"></i>
+    An example success alert with an icon
+    </div>
+    <div class="alert alert-warning d-flex align-items-center">
+    <i class="bi bi-exclamation-triangle-fill me-2"></i>
+    An example warning alert with an icon
+    </div>
+    <div class="alert alert-danger d-flex align-items-center">
+    <i class="bi bi-x-octagon-fill me-2"></i>
+    An example danger alert with an icon
+    </div>
+</div>
+-----
+Python
+
+```python
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+alerts = html.Div(
+    [
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-info-circle-fill me-2"),
+                "An example info alert with an icon",
+            ],
+            color="info",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-check-circle-fill me-2"),
+                "An example success alert with an icon",
+            ],
+            color="success",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-exclamation-triangle-fill me-2"),
+                "An example warning alert with an icon",
+            ],
+            color="warning",
+            class_name="d-flex align-items-center",
+        ),
+        dbc.Alert(
+            [
+                html.I(class_name="bi bi-x-octagon-fill me-2"),
+                "An example danger alert with an icon",
+            ],
+            color="danger",
+            class_name="d-flex align-items-center",
+        ),
+    ]
+)
+```
+-----
+R
+
+```r
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+alerts <- htmlDiv(
+  list(
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-info-circle-fill me-2"),
+        "An example info alert with an icon"
+      ),
+      color = "info",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-check-circle-fill me-2"),
+        "An example success alert with an icon"
+      ),
+      color = "success",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-exclamation-triangle-fill me-2"),
+        "An example warning alert with an icon"
+      ),
+      color = "warning",
+      class_name = "d-flex align-items-center"
+    ),
+    dbcAlert(
+      list(
+        htmlI(class_name = "bi bi-x-octagon-fill me-2"),
+        "An example danger alert with an icon"
+      ),
+      color = "danger",
+      class_name = "d-flex align-items-center"
+    )
+  )
+)
 ```
 
+-----
+Julia
+
+```julia
+using DashBootstrapComponents, DashHtmlComponents
+
+alerts = html_div([
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-info-circle-fill me-2"),
+            "An example info alert with an icon",
+        ],
+        color = "info",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-check-circle-fill me-2"),
+            "An example success alert with an icon",
+        ],
+        color = "success",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-exclamation-triangle-fill me-2"),
+            "An example warning alert with an icon",
+        ],
+        color = "warning",
+        class_name = "d-flex align-items-center",
+    ),
+    dbc_alert(
+        [
+            html_i(class_name = "bi bi-x-octagon-fill me-2"),
+            "An example danger alert with an icon",
+        ],
+        color = "danger",
+        class_name = "d-flex align-items-center",
+    ),
+])
+```
 ~~~

--- a/docs/content/docs/quickstart.md
+++ b/docs/content/docs/quickstart.md
@@ -181,6 +181,7 @@ Check out these [example apps][examples] made with _dash-bootstrap-components_.
 [dash-docs]: https://dash.plotly.com
 [dash-docs-external]: https://dash.plotly.com/external-resources
 [docs-themes]: /docs/themes
+[docs-icons]: /docs/icons
 [docs-components]: /docs/components
 [bootstrapcdn]: https://www.bootstrapcdn.com/
 [examples]: /examples

--- a/docs/demos/theme_explorer/__init__.py
+++ b/docs/demos/theme_explorer/__init__.py
@@ -21,8 +21,9 @@ from .tabs import tabs
 from .toast import toast
 from .tooltip import tooltip
 
-FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css"
-app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP, FONT_AWESOME])
+app = dash.Dash(
+    external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.FONT_AWESOME]
+)
 
 app.layout = dbc.Container(
     [

--- a/docs/markdown_to_html.py
+++ b/docs/markdown_to_html.py
@@ -28,6 +28,17 @@ TAB_OUTER_TEMPLATE = """<div class="card mb-3">
 </div>
 """  # noqa
 
+EXAMPLE_TAB_OUTER_TEMPLATE = """<div class="example-container">
+  <div class="example">
+    {example}
+  </div>
+  <div>
+    <ul class="px-3 nav nav-tabs{classes}"{id_value}>{tabs}</ul>
+    <div class="tab-content">{tab_panes}</div>
+  </div>
+</div>
+"""
+
 TAB_TEMPLATE = """<li class="nav-item" role="presentation">
   <a class="nav-link{2}" id="{0}-tab" data-bs-toggle="tab" data-bs-target="#{0}" role="tab" aria-controls="{0}" aria-selected="{3}">{1}</a>
 </li>
@@ -35,19 +46,17 @@ TAB_TEMPLATE = """<li class="nav-item" role="presentation">
 
 TAB_PANE_TEMPLATE = """<div class="tab-pane fade show{2}" id="{0}" role="tabpanel" aria-labelledby="{0}-tab">{1}</div>"""  # noqa
 
+EXAMPLE_TAB_PANE_TEMPLATE = """<div class="tab-pane fade show{2}" id="{0}" role="tabpanel" aria-labelledby="{0}-tab"><div><div class="m-3">{1}</div></div></div>"""  # noqa
+
 TAB_COUNT = 0
 
 
-def tab_formatter(source, language, class_name, options, md, **kwargs):
-    """Format source as tabs."""
-    global TAB_COUNT
-    TAB_COUNT += 1
-
-    source = [chunk.split("\n", 1) for chunk in source.split("-----\n")]
-
+def prepare_tabs(source, class_name, kwargs, tab_count, example=False):
     classes = kwargs["classes"]
     id_value = kwargs["id_value"]
     attrs = kwargs["attrs"]
+
+    tab_template = EXAMPLE_TAB_PANE_TEMPLATE if example else TAB_PANE_TEMPLATE
 
     if class_name:
         classes.insert(0, class_name)
@@ -63,21 +72,57 @@ def tab_formatter(source, language, class_name, options, md, **kwargs):
     tabs = ""
     tab_panes = ""
     for i, (tab_name, tab_content) in enumerate(source):
-        tab_id = re.sub(r"\s", "_", tab_name).lower() + str(TAB_COUNT)
+        tab_id = re.sub(r"\s", "_", tab_name).lower() + str(tab_count)
         tabs += TAB_TEMPLATE.format(
             tab_id,
             tab_name,
             " active" if i == 0 else "",
             "true" if i == 0 else "false",
         )
-        tab_panes += TAB_PANE_TEMPLATE.format(
+        tab_panes += tab_template.format(
             tab_id,
             markdown.markdown(tab_content, extensions=["fenced_code", "meta"]),
             " active" if i == 0 else "",
         )
 
+    return tabs, tab_panes, id_value, classes
+
+
+def tab_formatter(source, language, class_name, options, md, **kwargs):
+    """Format source as tabs."""
+    global TAB_COUNT
+    TAB_COUNT += 1
+
+    source = [chunk.split("\n", 1) for chunk in source.split("-----\n")]
+
+    tabs, tab_panes, id_value, classes = prepare_tabs(
+        source, class_name, kwargs, TAB_COUNT
+    )
+
     return TAB_OUTER_TEMPLATE.format(
         tabs=tabs, tab_panes=tab_panes, id_value=id_value, classes=classes
+    )
+
+
+def example_tab_formatter(source, language, class_name, options, md, **kwargs):
+    """Format source as tabs with example"""
+    global TAB_COUNT
+    TAB_COUNT += 1
+
+    chunks = source.split("-----\n")
+    example = chunks[0]
+    source = [chunk.split("\n", 1) for chunk in chunks[1:]]
+
+    tabs, tab_panes, id_value, classes = prepare_tabs(
+        source, class_name, kwargs, TAB_COUNT, example=True
+    )
+
+    return EXAMPLE_TAB_OUTER_TEMPLATE.format(
+        example=example,
+        tabs=tabs,
+        tab_panes=tab_panes,
+        id_value=id_value,
+        classes=classes,
     )
 
 
@@ -88,7 +133,12 @@ extension_configs = {
                 "name": "bootstrap-tabs",
                 "class": "bootstrap-tabs",
                 "format": tab_formatter,
-            }
+            },
+            {
+                "name": "bootstrap-example-tabs",
+                "class": "bootstrap-example-tabs",
+                "format": example_tab_formatter,
+            },
         ]
     }
 }

--- a/docs/server.py
+++ b/docs/server.py
@@ -4,6 +4,7 @@ from jinja2 import TemplateNotFound
 DOCS_SIDENAV_ITEMS = [
     {"name": "quickstart", "href": "/docs/quickstart", "label": "Quickstart"},
     {"name": "themes", "href": "/docs/themes", "label": "Themes"},
+    {"name": "icons", "href": "/docs/icons", "label": "Icons"},
     {"name": "faq", "href": "/docs/faq", "label": "FAQ"},
     {"name": "components", "href": "/docs/components", "label": "Components"},
 ]
@@ -66,6 +67,17 @@ def create_server():
     def theme_explorer():
         try:
             return render_template("theme-explorer.html")
+        except TemplateNotFound:
+            abort(404)
+
+    @server.route("/docs/icons/")
+    def icons():
+        try:
+            return render_template(
+                "generated/docs/icons.html",
+                sidenav_items=DOCS_SIDENAV_ITEMS,
+                sidenav_active="icons",
+            )
         except TemplateNotFound:
             abort(404)
 

--- a/docs/templates/partials/head.html
+++ b/docs/templates/partials/head.html
@@ -16,3 +16,7 @@
   type="image/png"
   href="/static/images/dbciconwhite16.png"
 />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+/>

--- a/jl/icons.jl
+++ b/jl/icons.jl
@@ -2,5 +2,5 @@ export dbc_icons
 
 dbc_icons = (
     BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css",
-    FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css",
+    FONT_AWESOME = "https://use.fontawesome.com/releases/v5.15.4/css/all.css",
 )

--- a/jl/icons.jl
+++ b/jl/icons.jl
@@ -1,0 +1,6 @@
+export dbc_icons
+
+dbc_icons = (
+    BOOTSTRAP = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css",
+    FONT_AWESOME = "https://use.fontawesome.com/releases/v5.10.2/css/all.css",
+)

--- a/tasks.py
+++ b/tasks.py
@@ -236,6 +236,7 @@ def move_generated_files(_):
             "__init__.py",
             "_table.py",
             "_version.py",
+            "icons.py",
             "themes.py",
         ):
             continue
@@ -263,6 +264,7 @@ def build_r(ctx):
     move_generated_files(ctx)
     with (HERE / "NAMESPACE").open("a") as f:
         f.write("\nexport(dbcThemes)\n")
+        f.write("\nexport(dbcIcons)\n")
 
     # -dev suffix breaks local installs of R package
     description = (HERE / "DESCRIPTION").read_text().split("\n")
@@ -285,6 +287,7 @@ def build_jl(ctx):
     copy_dist()
     move_generated_files(ctx)
     shutil.copy(HERE / "jl" / "themes.jl", HERE / "src" / "jl" / "themes.jl")
+    shutil.copy(HERE / "jl" / "icons.jl", HERE / "src" / "jl" / "icons.jl")
 
     with (HERE / "src" / "DashBootstrapComponents.jl").open() as f:
         lines = f.readlines()
@@ -295,6 +298,7 @@ def build_jl(ctx):
             break
 
     lines.insert(n - i, 'include("jl/themes.jl")\n')
+    lines.insert(n - i, 'include("jl/icons.jl")\n')
 
     with (HERE / "src" / "DashBootstrapComponents.jl").open("w") as f:
         f.writelines(lines)


### PR DESCRIPTION
As per #651 I have added a page to explain how to add the Bootstrap icons (as well as font awesome as these are [recommended by Bootstrap](https://getbootstrap.com/docs/5.1/extend/icons/#alternatives). I looked at adding Feather and Octicons from their list too, but their usage didn't seem to align very well with how Dash works (but that could easily be my inexperience with them).

Bootstrap and Font Awesome icons are available via `dbc.icons.BOOTSTRAP` and `dbc.icons.FONT_AWESOME`. I've added some details on this to the `icons.md` page, but this is likely to need additional detail and explanation.

Finally, I included an example (as suggested in the original issue) where the alerts make use of the bootstrap icons.