### PR TITLE
Card documentation example improvements for V1

### DIFF
--- a/docs/components_page/components/card.md
+++ b/docs/components_page/components/card.md
@@ -67,6 +67,12 @@ Bootstrap comes with several CSS utility classes built in, including some for si
 
 {{example:components/card/sizing/utility.py:cards}}
 
+### Horizontal
+
+Using a combination of grid and utility classes, cards can be made horizontal in a mobile-friendly and responsive way. In the example below, we remove the grid gutters with `.g-0` and use `.col-md-*` classes to make the card horizontal at the `md` breakpoint. Further adjustments may be needed depending on your card content.
+
+{{example:components/card/sizing/horizontal.py:card}}
+
 ### Using custom CSS
 
 Finally, you can use custom CSS to control the size of your cards. In this example we use the `style` argument of `Card` to set inline style arguments. You can also write your own CSS classes that specify `width`, `max-width` etc. and apply them to the card.

--- a/docs/components_page/components/card.md
+++ b/docs/components_page/components/card.md
@@ -67,12 +67,6 @@ Bootstrap comes with several CSS utility classes built in, including some for si
 
 {{example:components/card/sizing/utility.py:cards}}
 
-### Horizontal
-
-Using a combination of grid and utility classes, cards can be made horizontal in a mobile-friendly and responsive way. In the example below, we remove the grid gutters with `.g-0` and use `.col-md-*` classes to make the card horizontal at the `md` breakpoint. Further adjustments may be needed depending on your card content.
-
-{{example:components/card/sizing/horizontal.py:card}}
-
 ### Using custom CSS
 
 Finally, you can use custom CSS to control the size of your cards. In this example we use the `style` argument of `Card` to set inline style arguments. You can also write your own CSS classes that specify `width`, `max-width` etc. and apply them to the card.
@@ -80,6 +74,12 @@ Finally, you can use custom CSS to control the size of your cards. In this examp
 {{example:components/card/sizing/css.py:cards}}
 
 ## Card style
+
+### Horizontal
+
+Using a combination of grid and utility classes, cards can be made horizontal in a mobile-friendly and responsive way. In the example below, we remove the grid gutters with `.g-0` and use `.col-md-*` classes to make the card horizontal at the `md` breakpoint. Further adjustments may be needed depending on your card content.
+
+{{example:components/card/sizing/horizontal.py:card}}
 
 ### Background and color
 

--- a/docs/components_page/components/card.md
+++ b/docs/components_page/components/card.md
@@ -33,6 +33,12 @@ Use `CardImg` when adding images to cards. The `top` argument can be used when t
 
 {{example:components/card/image.py:cards}}
 
+### Image Overlays
+
+Use `CardImgOverlay` to display the card content over the top of the card image. Depending on the image, you may or may not need additional styles or utilities.
+
+{{example:components/card/image_overlay.py:card}}
+
 ### List groups
 
 Create lists of content in a card with a `ListGroup` component by setting `flush=True`.

--- a/docs/components_page/components/card/image_overlay.R
+++ b/docs/components_page/components/card/image_overlay.R
@@ -2,23 +2,23 @@ library(dashBootstrapComponents)
 library(dashHtmlComponents)
 
 card <- dbcCard(
-    list(
-        dbcCardImg(src="/static/images/placeholder286x180.png", top=TRUE),
-        dbcCardImgOverlay(
-            dbcCardBody(
-                list(
-                    htmlH4("Card title", class_name="card-title"),
-                    htmlP(
-                        paste(
-                        "An example of using an image in the background of",
-                        "a card.",
-                        )
-                        class_name="card-text"
-                    ),
-                    dbcButton("Go somewhere", color="primary")
-                )
-            )
+  list(
+    dbcCardImg(src = "/static/images/placeholder286x180.png", top = TRUE),
+    dbcCardImgOverlay(
+      dbcCardBody(
+        list(
+          htmlH4("Card title", class_name = "card-title"),
+          htmlP(
+            paste(
+              "An example of using an image in the background of",
+              "a card."
+            ),
+            class_name = "card-text"
+          ),
+          dbcButton("Go somewhere", color = "primary")
         )
-    ),
-    style=list("width" = "18rem")
+      )
+    )
+  ),
+  style = list("width" = "18rem")
 )

--- a/docs/components_page/components/card/image_overlay.R
+++ b/docs/components_page/components/card/image_overlay.R
@@ -9,8 +9,10 @@ card <- dbcCard(
                 list(
                     htmlH4("Card title", class_name="card-title"),
                     htmlP(
-                        "An example of using an image in the background of "
+                        paste(
+                        "An example of using an image in the background of",
                         "a card.",
+                        )
                         class_name="card-text"
                     ),
                     dbcButton("Go somewhere", color="primary")

--- a/docs/components_page/components/card/image_overlay.R
+++ b/docs/components_page/components/card/image_overlay.R
@@ -1,0 +1,22 @@
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+card <- dbcCard(
+    list(
+        dbcCardImg(src="/static/images/placeholder286x180.png", top=TRUE),
+        dbcCardImgOverlay(
+            dbcCardBody(
+                list(
+                    htmlH4("Card title", class_name="card-title"),
+                    htmlP(
+                        "An example of using an image in the background of "
+                        "a card.",
+                        class_name="card-text"
+                    ),
+                    dbcButton("Go somewhere", color="primary")
+                )
+            )
+        )
+    ),
+    style=list("width" = "18rem")
+)

--- a/docs/components_page/components/card/image_overlay.jl
+++ b/docs/components_page/components/card/image_overlay.jl
@@ -8,7 +8,7 @@ card <- dbc_card(
                 [
                     html_h4("Card title", class_name="card-title"),
                     html_p(
-                        "An example of using an image in the background of "
+                        "An example of using an image in the background of " *
                         "a card.",
                         class_name="card-text",
                     ),

--- a/docs/components_page/components/card/image_overlay.jl
+++ b/docs/components_page/components/card/image_overlay.jl
@@ -1,0 +1,21 @@
+using DashBootstrapComponents, DashHtmlComponents
+
+card <- dbc_card(
+    [
+        dbc_cardimg(src="/static/images/placeholder286x180.png", top=true),
+        dbc_cardimgoverlay(
+            dbc_cardbody(
+                [
+                    html_h4("Card title", class_name="card-title"),
+                    html_p(
+                        "An example of using an image in the background of "
+                        "a card.",
+                        class_name="card-text",
+                    ),
+                    dbc_button("Go somewhere", color="primary"),
+                ],
+            ),
+        ),
+    ],
+    style=Dict("width" => "18rem"),
+)

--- a/docs/components_page/components/card/image_overlay.jl
+++ b/docs/components_page/components/card/image_overlay.jl
@@ -1,21 +1,18 @@
 using DashBootstrapComponents, DashHtmlComponents
 
-card <- dbc_card(
+card = dbc_card(
     [
-        dbc_cardimg(src="/static/images/placeholder286x180.png", top=true),
+        dbc_cardimg(src = "/static/images/placeholder286x180.png", top = true),
         dbc_cardimgoverlay(
-            dbc_cardbody(
-                [
-                    html_h4("Card title", class_name="card-title"),
-                    html_p(
-                        "An example of using an image in the background of " *
-                        "a card.",
-                        class_name="card-text",
-                    ),
-                    dbc_button("Go somewhere", color="primary"),
-                ],
-            ),
+            dbc_cardbody([
+                html_h4("Card title", class_name = "card-title"),
+                html_p(
+                    "An example of using an image in the background of " * "a card.",
+                    class_name = "card-text",
+                ),
+                dbc_button("Go somewhere", color = "primary"),
+            ],),
         ),
     ],
-    style=Dict("width" => "18rem"),
+    style = Dict("width" => "18rem"),
 )

--- a/docs/components_page/components/card/image_overlay.py
+++ b/docs/components_page/components/card/image_overlay.py
@@ -1,0 +1,22 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+card = dbc.Card(
+    [
+        dbc.CardImg(src="/static/images/placeholder286x180.png", top=True),
+        dbc.CardImgOverlay(
+            dbc.CardBody(
+                [
+                    html.H4("Card title", class_name="card-title"),
+                    html.P(
+                        "An example of using an image in the background of "
+                        "a card.",
+                        class_name="card-text",
+                    ),
+                    dbc.Button("Go somewhere", color="primary"),
+                ],
+            ),
+        ),
+    ],
+    style={"width": "18rem"},
+)

--- a/docs/components_page/components/card/sizing/horizontal.R
+++ b/docs/components_page/components/card/sizing/horizontal.R
@@ -1,0 +1,40 @@
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+card <- dbcCard(
+    list(
+        dbcRow(
+            list(
+                dbcCol(
+                    dbcCardImg(
+                        src="/static/images/placeholder286x180.png",
+                        class_name="img-fluid rounded-start"
+                    ),
+                    class_name="col-md-4"
+                ),
+                dbcCol(
+                    dbcCardBody(
+                        list(
+                            htmlH4("Card title", class_name="card-title"),
+                            htmlP(
+                                paste(
+                                "This is a wider card with supporting text"
+                                "below as a natural lead-in to additional"
+                                "content. This content is a bit longer."),
+                                class_name="card-text"
+                            ),
+                            htmlSmall(
+                                "Last updated 3 mins ago",
+                                class_name="card-text text-muted"
+                            ),
+                        )
+                    ),
+                    class_name="col-md-8"
+                )
+            ),
+            class_name="g-0 d-flex align-items-center"
+        )
+    ),
+    class_name="mb-3",
+    style=list("maxWidth" = "540px")
+)

--- a/docs/components_page/components/card/sizing/horizontal.R
+++ b/docs/components_page/components/card/sizing/horizontal.R
@@ -2,39 +2,40 @@ library(dashBootstrapComponents)
 library(dashHtmlComponents)
 
 card <- dbcCard(
-    list(
-        dbcRow(
+  list(
+    dbcRow(
+      list(
+        dbcCol(
+          dbcCardImg(
+            src = "/static/images/placeholder286x180.png",
+            class_name = "img-fluid rounded-start"
+          ),
+          class_name = "col-md-4"
+        ),
+        dbcCol(
+          dbcCardBody(
             list(
-                dbcCol(
-                    dbcCardImg(
-                        src="/static/images/placeholder286x180.png",
-                        class_name="img-fluid rounded-start"
-                    ),
-                    class_name="col-md-4"
+              htmlH4("Card title", class_name = "card-title"),
+              htmlP(
+                paste(
+                  "This is a wider card with supporting text",
+                  "below as a natural lead-in to additional",
+                  "content. This content is a bit longer."
                 ),
-                dbcCol(
-                    dbcCardBody(
-                        list(
-                            htmlH4("Card title", class_name="card-title"),
-                            htmlP(
-                                paste(
-                                "This is a wider card with supporting text"
-                                "below as a natural lead-in to additional"
-                                "content. This content is a bit longer."),
-                                class_name="card-text"
-                            ),
-                            htmlSmall(
-                                "Last updated 3 mins ago",
-                                class_name="card-text text-muted"
-                            ),
-                        )
-                    ),
-                    class_name="col-md-8"
-                )
-            ),
-            class_name="g-0 d-flex align-items-center"
+                class_name = "card-text"
+              ),
+              htmlSmall(
+                "Last updated 3 mins ago",
+                class_name = "card-text text-muted"
+              )
+            )
+          ),
+          class_name = "col-md-8"
         )
-    ),
-    class_name="mb-3",
-    style=list("maxWidth" = "540px")
+      ),
+      class_name = "g-0 d-flex align-items-center"
+    )
+  ),
+  class_name = "mb-3",
+  style = list("maxWidth" = "540px")
 )

--- a/docs/components_page/components/card/sizing/horizontal.jl
+++ b/docs/components_page/components/card/sizing/horizontal.jl
@@ -1,0 +1,38 @@
+using DashBootstrapComponents, DashHtmlComponents
+
+card = dbc_card(
+    [
+        dbc_row(
+            [
+                dbc_col(
+                    dbc_cardimg(
+                        src="/static/images/placeholder286x180.png",
+                        class_name="img-fluid rounded-start",
+                    ),
+                    class_name="col-md-4",
+                ),
+                dbc_col(
+                    dbc_cardbody(
+                        [
+                            html_h4("Card title", class_name="card-title"),
+                            html_p(
+                                "This is a wider card with supporting text " *
+                                "below as a natural lead-in to additional " *
+                                "content. This content is a bit longer.",
+                                class_name="card-text",
+                            ),
+                            html_small(
+                                "Last updated 3 mins ago",
+                                class_name="card-text text-muted",
+                            ),
+                        ]
+                    ),
+                    class_name="col-md-8",
+                ),
+            ],
+            class_name="g-0 d-flex align-items-center",
+        )
+    ],
+    class_name="mb-3",
+    style=Dict("maxWidth" => "540px"),
+)

--- a/docs/components_page/components/card/sizing/horizontal.jl
+++ b/docs/components_page/components/card/sizing/horizontal.jl
@@ -6,33 +6,31 @@ card = dbc_card(
             [
                 dbc_col(
                     dbc_cardimg(
-                        src="/static/images/placeholder286x180.png",
-                        class_name="img-fluid rounded-start",
+                        src = "/static/images/placeholder286x180.png",
+                        class_name = "img-fluid rounded-start",
                     ),
-                    class_name="col-md-4",
+                    class_name = "col-md-4",
                 ),
                 dbc_col(
-                    dbc_cardbody(
-                        [
-                            html_h4("Card title", class_name="card-title"),
-                            html_p(
-                                "This is a wider card with supporting text " *
-                                "below as a natural lead-in to additional " *
-                                "content. This content is a bit longer.",
-                                class_name="card-text",
-                            ),
-                            html_small(
-                                "Last updated 3 mins ago",
-                                class_name="card-text text-muted",
-                            ),
-                        ]
-                    ),
-                    class_name="col-md-8",
+                    dbc_cardbody([
+                        html_h4("Card title", class_name = "card-title"),
+                        html_p(
+                            "This is a wider card with supporting text " *
+                            "below as a natural lead-in to additional " *
+                            "content. This content is a bit longer.",
+                            class_name = "card-text",
+                        ),
+                        html_small(
+                            "Last updated 3 mins ago",
+                            class_name = "card-text text-muted",
+                        ),
+                    ]),
+                    class_name = "col-md-8",
                 ),
             ],
-            class_name="g-0 d-flex align-items-center",
-        )
+            class_name = "g-0 d-flex align-items-center",
+        ),
     ],
-    class_name="mb-3",
-    style=Dict("maxWidth" => "540px"),
+    class_name = "mb-3",
+    style = Dict("maxWidth" => "540px"),
 )

--- a/docs/components_page/components/card/sizing/horizontal.py
+++ b/docs/components_page/components/card/sizing/horizontal.py
@@ -1,0 +1,39 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+card = dbc.Card(
+    [
+        dbc.Row(
+            [
+                dbc.Col(
+                    dbc.CardImg(
+                        src="/static/images/placeholder286x180.png",
+                        class_name="img-fluid rounded-start",
+                    ),
+                    class_name="col-md-4",
+                ),
+                dbc.Col(
+                    dbc.CardBody(
+                        [
+                            html.H4("Card title", class_name="card-title"),
+                            html.P(
+                                "This is a wider card with supporting text "
+                                "below as a natural lead-in to additional "
+                                "content. This content is a bit longer.",
+                                class_name="card-text",
+                            ),
+                            html.Small(
+                                "Last updated 3 mins ago",
+                                class_name="card-text text-muted",
+                            ),
+                        ]
+                    ),
+                    class_name="col-md-8",
+                ),
+            ],
+            class_name="g-0 d-flex align-items-center",
+        )
+    ],
+    class_name="mb-3",
+    style={"maxWidth": "540px"},
+)


### PR DESCRIPTION
As requested in #651 , added an example for card image overlay and horizontal cards. The placeholder images used in them may need revisiting to improve visibility in the former, and to increase the height of the card in the latter.