### PR TITLE
Stop loading_state being passed to components

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -209,6 +209,13 @@ Modal.propTypes = {
   /**
    * Set the z-index of the modal. Default 1050.
    */
+  zindex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+  /**
+   * **DEPRECATED** Use `zindex` instead
+   *
+   * Set the z-index of the modal. Default 1050.
+   */
   zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 

--- a/src/components/modal/ModalBody.js
+++ b/src/components/modal/ModalBody.js
@@ -8,11 +8,21 @@ import RBModalBody from 'react-bootstrap/ModalBody';
  * your Modals.
  */
 const ModalBody = props => {
-  const {children, className, class_name, tag, ...otherProps} = props;
+  const {
+    children,
+    loading_state,
+    className,
+    class_name,
+    tag,
+    ...otherProps
+  } = props;
   return (
     <RBModalBody
       as={tag}
       className={class_name || className}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -52,7 +62,25 @@ ModalBody.propTypes = {
   /**
    * HTML tag to use for the ModalBody, default: div
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default ModalBody;

--- a/src/components/modal/ModalFooter.js
+++ b/src/components/modal/ModalFooter.js
@@ -7,11 +7,21 @@ import RBModalFooter from 'react-bootstrap/ModalFooter';
  * Add a footer to any modal.
  */
 const ModalFooter = props => {
-  const {children, className, class_name, tag, ...otherProps} = props;
+  const {
+    children,
+    loading_state,
+    className,
+    class_name,
+    tag,
+    ...otherProps
+  } = props;
   return (
     <RBModalFooter
       as={tag}
       className={class_name || className}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -51,7 +61,25 @@ ModalFooter.propTypes = {
   /**
    * HTML tag to use for the ModalFooter, default: div
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default ModalFooter;

--- a/src/components/modal/ModalHeader.js
+++ b/src/components/modal/ModalHeader.js
@@ -9,6 +9,7 @@ import RBModalHeader from 'react-bootstrap/ModalHeader';
 const ModalHeader = props => {
   const {
     children,
+    loading_state,
     className,
     class_name,
     tag,
@@ -20,6 +21,9 @@ const ModalHeader = props => {
       as={tag}
       className={class_name || className}
       closeButton={close_button}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -68,7 +72,25 @@ ModalHeader.propTypes = {
   /**
    * HTML tag to use for the ModalHeader, default: div
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default ModalHeader;

--- a/src/components/modal/ModalTitle.js
+++ b/src/components/modal/ModalTitle.js
@@ -7,11 +7,21 @@ import RBModalTitle from 'react-bootstrap/ModalTitle';
  * Add a title to any modal. Should be used as a child of the ModalHeader.
  */
 const ModalTitle = props => {
-  const {children, className, class_name, tag, ...otherProps} = props;
+  const {
+    children,
+    loading_state,
+    className,
+    class_name,
+    tag,
+    ...otherProps
+  } = props;
   return (
     <RBModalTitle
       as={tag}
       className={class_name || className}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -51,7 +61,25 @@ ModalTitle.propTypes = {
   /**
    * HTML tag to use for the ModalTitle, default: div
    */
-  tag: PropTypes.string
+  tag: PropTypes.string,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default ModalTitle;

--- a/src/components/offcanvas/Offcanvas.js
+++ b/src/components/offcanvas/Offcanvas.js
@@ -11,6 +11,7 @@ const Offcanvas = props => {
     is_open,
     setProps,
     children,
+    loading_state,
     class_name,
     className,
     backdrop,
@@ -52,6 +53,9 @@ const Offcanvas = props => {
       show={is_open}
       onHide={backdrop !== 'static' ? onHide : null}
       backdrop={backdrop || backdrop === 'static'}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...otherProps}
     >
       {header}
@@ -167,7 +171,25 @@ Offcanvas.propTypes = {
    * Specify whether the Component should contain a close button
    * in the header
    */
-  close_button: PropTypes.bool
+  close_button: PropTypes.bool,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default Offcanvas;

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -18,6 +18,7 @@ const Pagination = props => {
     setProps,
     class_name,
     className,
+    loading_state,
     ...otherProps
   } = props;
 
@@ -138,7 +139,13 @@ const Pagination = props => {
 
   // Create the pagination component
   return (
-    <RBPagination className={class_name || className} {...otherProps}>
+    <RBPagination
+      className={class_name || className}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
+      {...otherProps}
+    >
       {paginationItems}
     </RBPagination>
   );
@@ -221,7 +228,25 @@ Pagination.propTypes = {
    * When True, this will display a first and last icon at the beginning
    * and end of the component.
    */
-  first_last: PropTypes.bool
+  first_last: PropTypes.bool,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default Pagination;

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -12,6 +12,7 @@ import RBToast from 'react-bootstrap/Toast';
 const Toast = props => {
   const {
     children,
+    loading_state,
     header,
     icon,
     header_style,
@@ -60,6 +61,9 @@ const Toast = props => {
       onClose={dismissable && dismiss}
       className={class_name || className}
       bg={color}
+      data-dash-is-loading={
+        (loading_state && loading_state.is_loading) || undefined
+      }
       {...omit(['n_dismiss_timestamp'], otherProps)}
     >
       <RBToast.Header
@@ -230,7 +234,25 @@ Toast.propTypes = {
    * Toast color, options: primary, secondary, success, info, warning, danger,
    * light, dark. Default: secondary.
    */
-  color: PropTypes.string
+  color: PropTypes.string,
+
+  /**
+   * Object that holds the loading state object coming from dash-renderer
+   */
+  loading_state: PropTypes.shape({
+    /**
+     * Determines if the component is loading or not
+     */
+    is_loading: PropTypes.bool,
+    /**
+     * Holds which property is loading
+     */
+    prop_name: PropTypes.string,
+    /**
+     * Holds the name of the component that is loading
+     */
+    component_name: PropTypes.string
+  })
 };
 
 export default Toast;


### PR DESCRIPTION
As documented in #651 , the modal components were being passed loading_state. I also identified a few other components where this was also the case, so I have fixed these.