### PR TITLE
Removed text decoration from nav links

### DIFF
--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -214,6 +214,7 @@ span.hljs-meta {
   font-weight: 500;
   font-size: 1.25rem;
   color: rgba(0, 0, 0, 0.65);
+  text-decoration: none;
 }
 
 .dbcd-nav-link:hover {
@@ -232,6 +233,7 @@ span.hljs-meta {
 .dbcd-nav-links ul > li > a {
   padding: 0.25rem 0rem;
   color: rgba(0, 0, 0, 0.65);
+  text-decoration: none;
 }
 
 .dbcd-nav-links ul > li.active > a {


### PR DESCRIPTION
As per #651, I've removed the text decoration in the side navigation which was introduced in Bootstrap 5. I have left it in the main body though.