### PR TITLE
Example with collapsible sidebar and navbar

### DIFF
--- a/examples/python/templates/multi-page-apps/responsive-collapsible-sidebar-navbar/app.py
+++ b/examples/python/templates/multi-page-apps/responsive-collapsible-sidebar-navbar/app.py
@@ -1,0 +1,171 @@
+"""
+This app creates a collapsible, responsive sidebar layout with
+dash-bootstrap-components and some custom css with media queries.
+
+When the screen is small, the sidebar moved to the top of the page, and the
+links get hidden in a collapse element. We use a callback to toggle the
+collapse when on a small screen, and the custom CSS to hide the toggle, and
+force the collapse to stay open when the screen is large.
+
+dcc.Location is used to track the current location, a callback uses the current
+location to render the appropriate page content. The active prop of each
+NavLink is set automatically according to the current pathname. To use this
+feature you must install dash-bootstrap-components >= 0.11.0.
+
+For more details on building multi-page Dash applications, check out the Dash
+documentation: https://dash.plot.ly/urls
+"""
+import dash
+import dash_bootstrap_components as dbc
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+
+FA = "https://use.fontawesome.com/releases/v5.15.1/css/all.css"
+PLOTLY_LOGO = "https://images.plot.ly/logo/new-branding/plotly-logomark.png"
+
+app = dash.Dash(
+    external_stylesheets=[dbc.themes.BOOTSTRAP, FA],
+    # these meta_tags ensure content is scaled correctly on different devices
+    # see: https://www.w3schools.com/css/css_rwd_viewport.asp for more
+    meta_tags=[
+        {"name": "viewport", "content": "width=device-width, initial-scale=1"}
+    ],
+)
+
+navbar = dbc.NavbarSimple(
+    children=[
+        dbc.NavItem(
+            dbc.NavLink(
+                [
+                    html.I(className="fas fa-envelope-open-text mr-2"),
+                    html.Span("Messages"),
+                ],
+                href="/messages",
+                active="exact",
+            ),
+        ),
+    ],
+    brand="LONG BRAND NAME",
+    brand_href="/",
+)
+
+# we use the Row and Col components to construct the sidebar header
+# it consists of a title, and a toggle, the latter is hidden on large screens
+sidebar_header = dbc.Row(
+    [
+        dbc.Col(html.H2("Sidebar", className="display-4")),
+        dbc.Col(
+            [
+                html.Button(
+                    # use the Bootstrap navbar-toggler classes to style
+                    html.Span(className="navbar-toggler-icon"),
+                    className="navbar-toggler",
+                    # the navbar-toggler classes don't set color
+                    style={
+                        "color": "rgba(0,0,0,.5)",
+                        "border-color": "rgba(0,0,0,.1)",
+                    },
+                    id="navbar-toggle",
+                ),
+                html.Button(
+                    # use the Bootstrap navbar-toggler classes to style
+                    html.Span(className="navbar-toggler-icon"),
+                    className="navbar-toggler",
+                    # the navbar-toggler classes don't set color
+                    style={
+                        "color": "rgba(0,0,0,.5)",
+                        "border-color": "rgba(0,0,0,.1)",
+                    },
+                    id="sidebar-toggle",
+                ),
+            ],
+            # the column containing the toggle will be only as wide as the
+            # toggle, resulting in the toggle being right aligned
+            width="auto",
+            # vertically align the toggle in the center
+            align="center",
+        ),
+    ]
+)
+
+sidebar = html.Div(
+    [
+        sidebar_header,
+        # we wrap the horizontal rule and short blurb in a div that can be
+        # hidden on a small screen
+        html.Div(
+            [
+                html.Hr(),
+                html.P(
+                    "A responsive sidebar layout with collapsible navigation "
+                    "links.",
+                    className="lead",
+                ),
+            ],
+            id="blurb",
+        ),
+        # use the Collapse component to animate hiding / revealing links
+        dbc.Collapse(
+            dbc.Nav(
+                [
+                    dbc.NavLink("Home", href="/", active="exact"),
+                    dbc.NavLink("Page 1", href="/page-1", active="exact"),
+                    dbc.NavLink("Page 2", href="/page-2", active="exact"),
+                ],
+                vertical=True,
+                pills=True,
+            ),
+            id="collapse",
+        ),
+    ],
+    id="sidebar",
+)
+
+content = html.Div(id="page-content")
+
+app.layout = html.Div([dcc.Location(id="url"), navbar, sidebar, content])
+
+
+@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+def render_page_content(pathname):
+    if pathname == "/":
+        return html.P("This is the content of the home page!")
+    elif pathname == "/page-1":
+        return html.P("This is the content of page 1. Yay!")
+    elif pathname == "/page-2":
+        return html.P("Oh cool, this is page 2!")
+    # If the user tries to reach a different page, return a 404 message
+    return dbc.Jumbotron(
+        [
+            html.H1("404: Not found", className="text-danger"),
+            html.Hr(),
+            html.P(f"The pathname {pathname} was not recognised..."),
+        ]
+    )
+
+
+@app.callback(
+    Output("sidebar", "className"),
+    [Input("sidebar-toggle", "n_clicks")],
+    [State("sidebar", "className")],
+)
+def toggle_classname(n, classname):
+    if n and classname == "":
+        return "collapsed"
+    return ""
+
+
+@app.callback(
+    Output("collapse", "is_open"),
+    [Input("navbar-toggle", "n_clicks")],
+    [State("collapse", "is_open")],
+)
+def toggle_collapse(n, is_open):
+    if n:
+        return not is_open
+    return is_open
+
+
+if __name__ == "__main__":
+    app.run_server(port=8888, debug=True)

--- a/examples/python/templates/multi-page-apps/responsive-collapsible-sidebar-navbar/assets/responsive-sidebar.css
+++ b/examples/python/templates/multi-page-apps/responsive-collapsible-sidebar-navbar/assets/responsive-sidebar.css
@@ -1,0 +1,95 @@
+#sidebar {
+  text-align: center;
+  padding: 2rem 1rem;
+  background-color: #f8f9fa;
+}
+
+#sidebar h2 {
+  text-align: left;
+  margin-bottom: 0;
+}
+
+/* Hide the blurb on a small screen */
+#blurb {
+  display: none;
+}
+
+#sidebar-toggle {
+  display: none;
+}
+
+#collapse *:first-child {
+  margin-top: 1rem;
+}
+
+/* add the three horizontal bars icon for the toggle */
+.navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+#page-content {
+  padding: 2rem 1rem;
+}
+
+@media (min-width: 48em) {
+  #sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 20rem;
+    text-align: left;
+    transition: margin 0.3s ease-in-out, padding 0.3s ease-in-out;
+  }
+
+  #sidebar-toggle {
+    display: inline-block;
+    position: relative;
+    top: 0;
+    transition: top 0.3s ease-in-out;
+  }
+
+  /* add negative margin to sidebar to achieve the collapse */
+  #sidebar.collapsed {
+    margin-left: -15.5rem;
+    padding-right: 0.5rem;
+  }
+
+  /* move the sidebar toggle up to the top left corner */
+  #sidebar.collapsed #sidebar-toggle {
+    top: -2rem;
+  }
+
+  /* also adjust margin of page content */
+  #sidebar.collapsed ~ #page-content {
+    margin-left: 6.5rem;
+  }
+
+  /* move all contents of navbar other than header (containing toggle) further
+     off-screen */
+  #sidebar.collapsed > *:not(:first-child) {
+    margin-left: -6rem;
+    margin-right: 6rem;
+  }
+
+  /* reveal the blurb on a large screen */
+  #blurb {
+    display: block;
+  }
+
+  /* Hide the toggle on a large screen */
+  #navbar-toggle {
+    display: none;
+  }
+
+  #collapse {
+    display: block;
+  }
+
+  /* set margins of the main content so that it doesn't overlap the sidebar */
+  #page-content {
+    margin-left: 22rem;
+    margin-right: 2rem;
+    transition: margin-left 0.3s ease-in-out;
+  }
+}


### PR DESCRIPTION
Thank you very much for this awesome library.
I would like to suggest including an example (for multi-page apps) where both a collapsible sidebar and a navbar are present in the layout. What I have in mind is something similar to what we see in many bootstrap templates nowadays such as [this](https://adminlte.io/themes/v3/).

In this PR I have created the barebones of the example but since I'm very weak at the css part I cannot make it look right.
![image](https://user-images.githubusercontent.com/6556306/131583174-a35a4c22-bc4d-4e39-a3fb-dd70b44f8af2.png)

Any help to finish this example would be much appreciated