### PR TITLE
Added jumbotron example

### DIFF
--- a/docs/components_page/__init__.py
+++ b/docs/components_page/__init__.py
@@ -107,6 +107,7 @@ def register_apps():
         "form": {"markdown_path": COMPONENTS / "form.md"},
         "input": {"markdown_path": COMPONENTS / "input.md"},
         "input_group": {"markdown_path": COMPONENTS / "input_group.md"},
+        "jumbotron": {"markdown_path": COMPONENTS / "jumbotron.md"},
         "layout": {"markdown_path": COMPONENTS / "layout.md"},
         "list_group": {"markdown_path": COMPONENTS / "list_group.md"},
         "main": {"markdown_path": COMPONENTS / "main.md"},

--- a/docs/components_page/components/jumbotron.md
+++ b/docs/components_page/components/jumbotron.md
@@ -1,0 +1,16 @@
+---
+title: Jumbotron
+lead: Lightweight styling for showcasing key content and messages.
+---
+
+## Examples
+
+The Jumbotron was retired from Bootstrap use in Bootstrap 5, but as it's a useful layout, here are examples of how to combine the Bootstrap styling with Dash components to create a Jumbotron-like experience.
+
+{{example:components/jumbotron/simple.py:jumbotron}}
+
+### Styling the Jumbotron
+
+There are lots of styles and spacing options available in Bootstrap. Creating the perfect component is just about combining the ones you want in the right way.
+
+{{example:components/jumbotron/custom.py:jumbotron}}

--- a/docs/components_page/components/jumbotron.md
+++ b/docs/components_page/components/jumbotron.md
@@ -5,12 +5,12 @@ lead: Lightweight styling for showcasing key content and messages.
 
 ## Examples
 
-The Jumbotron was retired from Bootstrap use in Bootstrap 5, but as it's a useful layout, here are examples of how to combine the Bootstrap styling with Dash components to create a Jumbotron-like experience.
+The Jumbotron component was removed in Bootstrap 5, so there is no longer a dedicated `Jumbotron` component in _dash-bootstrap-components_ either. However, thanks to Bootstrap's flexible utility classes, it is easy to recreate a jumbotron-like layout yourself. Here's a simple example
 
 {{example:components/jumbotron/simple.py:jumbotron}}
 
-### Styling the Jumbotron
+### Styling the "Jumbotron"
 
-There are lots of styles and spacing options available in Bootstrap. Creating the perfect component is just about combining the ones you want in the right way.
+There are [many utility classes](https://getbootstrap.com/docs/5.0/utilities/spacing/) available in Bootstrap. By combining them you can easily customise the look and feel of your app.
 
 {{example:components/jumbotron/custom.py:jumbotron}}

--- a/docs/components_page/components/jumbotron/custom.R
+++ b/docs/components_page/components/jumbotron/custom.R
@@ -1,43 +1,43 @@
 library(dashBootstrapComponents)
 library(dashHtmlComponents)
 
-jumbotron <- dbcCol(
+left_jumbotron <- dbcCol(
   htmlDiv(
     list(
-      htmlH2("Change the background", class_name="display-3"),
-      htmlHr(class_name="my-2"),
+      htmlH2("Change the background", class_name = "display-3"),
+      htmlHr(class_name = "my-2"),
       htmlP(
         paste(
           "Swap the background-color utility and add a `.text-*` color",
           "utility to mix up the look."
         )
       ),
-      dbcButton("Example Button", color="light", outline=TRUE)
+      dbcButton("Example Button", color = "light", outline = TRUE)
     ),
-    class_name="h-100 p-5 text-white bg-dark rounded-3"
+    class_name = "h-100 p-5 text-white bg-dark rounded-3"
   ),
-  md=6
+  md = 6
 )
 
 right_jumbotron <- dbcCol(
   htmlDiv(
     list(
-      htmlH2("Add borders", class_name="display-3"),
-      htmlHr(class_name="my-2"),
+      htmlH2("Add borders", class_name = "display-3"),
+      htmlHr(class_name = "my-2"),
       htmlP(
         paste(
           "Or, keep it light and add a border for some added definition",
           "to the boundaries of your content."
         )
       ),
-      dbcButton("Example Button", color="secondary", outline=TRUE)
+      dbcButton("Example Button", color = "secondary", outline = TRUE)
     ),
-    class_name="h-100 p-5 bg-light border rounded-3"
+    class_name = "h-100 p-5 bg-light border rounded-3"
   ),
-  md=6
+  md = 6
 )
 
 jumbotron <- dbcRow(
   list(left_jumbotron, right_jumbotron),
-  class_name="align-items-md-stretch"
+  class_name = "align-items-md-stretch"
 )

--- a/docs/components_page/components/jumbotron/custom.R
+++ b/docs/components_page/components/jumbotron/custom.R
@@ -1,0 +1,43 @@
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+jumbotron <- dbcCol(
+  htmlDiv(
+    list(
+      htmlH2("Change the background", class_name="display-3"),
+      htmlHr(class_name="my-2"),
+      htmlP(
+        paste(
+          "Swap the background-color utility and add a `.text-*` color",
+          "utility to mix up the look."
+        )
+      ),
+      dbcButton("Example Button", color="light", outline=TRUE)
+    ),
+    class_name="h-100 p-5 text-white bg-dark rounded-3"
+  ),
+  md=6
+)
+
+right_jumbotron <- dbcCol(
+  htmlDiv(
+    list(
+      htmlH2("Add borders", class_name="display-3"),
+      htmlHr(class_name="my-2"),
+      htmlP(
+        paste(
+          "Or, keep it light and add a border for some added definition",
+          "to the boundaries of your content."
+        )
+      ),
+      dbcButton("Example Button", color="secondary", outline=TRUE)
+    ),
+    class_name="h-100 p-5 bg-light border rounded-3"
+  ),
+  md=6
+)
+
+jumbotron <- dbcRow(
+  list(left_jumbotron, right_jumbotron),
+  class_name="align-items-md-stretch"
+)

--- a/docs/components_page/components/jumbotron/custom.jl
+++ b/docs/components_page/components/jumbotron/custom.jl
@@ -3,36 +3,34 @@ using DashBootstrapComponents, DashHtmlComponents
 left_jumbotron = dbc_col(
     html_div(
         [
-            html_h2("Change the background", class_name="display-3"),
-            html_hr(class_name="my-2"),
+            html_h2("Change the background", class_name = "display-3"),
+            html_hr(class_name = "my-2"),
             html_p(
                 "Swap the background-color utility and add a `.text-*` color " *
-                "utility to mix up the look."
+                "utility to mix up the look.",
             ),
-            dbc_button("Example Button", color="light", outline=true),
+            dbc_button("Example Button", color = "light", outline = true),
         ],
-        class_name="h-100 p-5 text-white bg-dark rounded-3",
+        class_name = "h-100 p-5 text-white bg-dark rounded-3",
     ),
-    md=6,
+    md = 6,
 )
 
 right_jumbotron = dbc_col(
     html_div(
         [
-            html_h2("Add borders", class_name="display-3"),
-            html_hr(class_name="my-2"),
+            html_h2("Add borders", class_name = "display-3"),
+            html_hr(class_name = "my-2"),
             html_p(
                 "Or, keep it light and add a border for some added definition " *
-                "to the boundaries of your content."
+                "to the boundaries of your content.",
             ),
-            dbc_button("Example Button", color="secondary", outline=true),
+            dbc_button("Example Button", color = "secondary", outline = true),
         ],
-        class_name="h-100 p-5 bg-light border rounded-3",
+        class_name = "h-100 p-5 bg-light border rounded-3",
     ),
-    md=6,
+    md = 6,
 )
 
-jumbotron = dbc_row(
-    [left_jumbotron, right_jumbotron],
-    class_name="align-items-md-stretch",
-)
+jumbotron =
+    dbc_row([left_jumbotron, right_jumbotron], class_name = "align-items-md-stretch")

--- a/docs/components_page/components/jumbotron/custom.jl
+++ b/docs/components_page/components/jumbotron/custom.jl
@@ -1,0 +1,38 @@
+using DashBootstrapComponents, DashHtmlComponents
+
+left_jumbotron = dbc_col(
+    html_div(
+        [
+            html_h2("Change the background", class_name="display-3"),
+            html_hr(class_name="my-2"),
+            html_p(
+                "Swap the background-color utility and add a `.text-*` color " *
+                "utility to mix up the look."
+            ),
+            dbc_button("Example Button", color="light", outline=true),
+        ],
+        class_name="h-100 p-5 text-white bg-dark rounded-3",
+    ),
+    md=6,
+)
+
+right_jumbotron = dbc_col(
+    html_div(
+        [
+            html_h2("Add borders", class_name="display-3"),
+            html_hr(class_name="my-2"),
+            html_p(
+                "Or, keep it light and add a border for some added definition " *
+                "to the boundaries of your content."
+            ),
+            dbc_button("Example Button", color="secondary", outline=true),
+        ],
+        class_name="h-100 p-5 bg-light border rounded-3",
+    ),
+    md=6,
+)
+
+jumbotron = dbc_row(
+    [left_jumbotron, right_jumbotron],
+    class_name="align-items-md-stretch",
+)

--- a/docs/components_page/components/jumbotron/custom.py
+++ b/docs/components_page/components/jumbotron/custom.py
@@ -1,0 +1,39 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+left_jumbotron = dbc.Col(
+    html.Div(
+        [
+            html.H2("Change the background", class_name="display-3"),
+            html.Hr(class_name="my-2"),
+            html.P(
+                "Swap the background-color utility and add a `.text-*` color "
+                "utility to mix up the look."
+            ),
+            dbc.Button("Example Button", color="light", outline=True),
+        ],
+        class_name="h-100 p-5 text-white bg-dark rounded-3",
+    ),
+    md=6,
+)
+
+right_jumbotron = dbc.Col(
+    html.Div(
+        [
+            html.H2("Add borders", class_name="display-3"),
+            html.Hr(class_name="my-2"),
+            html.P(
+                "Or, keep it light and add a border for some added definition "
+                "to the boundaries of your content."
+            ),
+            dbc.Button("Example Button", color="secondary", outline=True),
+        ],
+        class_name="h-100 p-5 bg-light border rounded-3",
+    ),
+    md=6,
+)
+
+jumbotron = dbc.Row(
+    [left_jumbotron, right_jumbotron],
+    class_name="align-items-md-stretch",
+)

--- a/docs/components_page/components/jumbotron/simple.R
+++ b/docs/components_page/components/jumbotron/simple.R
@@ -1,0 +1,30 @@
+library(dashBootstrapComponents)
+library(dashHtmlComponents)
+
+jumbotron <- htmlDiv(
+  dbcContainer(
+    list(
+      htmlH1("Jumbotron", class_name="display-3"),
+      htmlP(
+        paste(
+          "Use Containers to create a jumbotron to call attention to",
+          "featured content or information."
+        ),
+        class_name="lead"
+      ),
+      htmlHr(class_name="my-2"),
+      htmlP(
+        paste(
+          "Use utility classes for typography and spacing to suit the",
+          "larger container."
+        )
+      ),
+      htmlP(
+        dbc.Button("Learn more", color="primary"), class_name="lead"
+      )
+    ),
+    fluid=TRUE,
+    class_name="py-3"
+  ),
+  class_name="p-3 bg-light rounded-3"
+)

--- a/docs/components_page/components/jumbotron/simple.R
+++ b/docs/components_page/components/jumbotron/simple.R
@@ -4,15 +4,15 @@ library(dashHtmlComponents)
 jumbotron <- htmlDiv(
   dbcContainer(
     list(
-      htmlH1("Jumbotron", class_name="display-3"),
+      htmlH1("Jumbotron", class_name = "display-3"),
       htmlP(
         paste(
           "Use Containers to create a jumbotron to call attention to",
           "featured content or information."
         ),
-        class_name="lead"
+        class_name = "lead"
       ),
-      htmlHr(class_name="my-2"),
+      htmlHr(class_name = "my-2"),
       htmlP(
         paste(
           "Use utility classes for typography and spacing to suit the",
@@ -20,11 +20,12 @@ jumbotron <- htmlDiv(
         )
       ),
       htmlP(
-        dbc.Button("Learn more", color="primary"), class_name="lead"
+        dbcButton("Learn more", color = "primary"),
+        class_name = "lead"
       )
     ),
-    fluid=TRUE,
-    class_name="py-3"
+    fluid = TRUE,
+    class_name = "py-3"
   ),
-  class_name="p-3 bg-light rounded-3"
+  class_name = "p-3 bg-light rounded-3"
 )

--- a/docs/components_page/components/jumbotron/simple.jl
+++ b/docs/components_page/components/jumbotron/simple.jl
@@ -1,0 +1,25 @@
+using DashBootstrapComponents, DashHtmlComponents
+
+jumbotron = html_div(
+    dbc_container(
+        [
+            html_h1("Jumbotron", class_name="display-3"),
+            html_p(
+                "Use Containers to create a jumbotron to call attention to " *
+                "featured content or information.",
+                class_name="lead",
+            ),
+            html_hr(class_name="my-2"),
+            html_p(
+                "Use utility classes for typography and spacing to suit the " *
+                "larger container."
+            ),
+            html_p(
+                dbc.Button("Learn more", color="primary"), class_name="lead"
+            ),
+        ],
+        fluid=true,
+        class_name="py-3",
+    ),
+    class_name="p-3 bg-light rounded-3",
+)

--- a/docs/components_page/components/jumbotron/simple.jl
+++ b/docs/components_page/components/jumbotron/simple.jl
@@ -3,23 +3,21 @@ using DashBootstrapComponents, DashHtmlComponents
 jumbotron = html_div(
     dbc_container(
         [
-            html_h1("Jumbotron", class_name="display-3"),
+            html_h1("Jumbotron", class_name = "display-3"),
             html_p(
                 "Use Containers to create a jumbotron to call attention to " *
                 "featured content or information.",
-                class_name="lead",
+                class_name = "lead",
             ),
-            html_hr(class_name="my-2"),
+            html_hr(class_name = "my-2"),
             html_p(
                 "Use utility classes for typography and spacing to suit the " *
-                "larger container."
+                "larger container.",
             ),
-            html_p(
-                dbc.Button("Learn more", color="primary"), class_name="lead"
-            ),
+            html_p(dbc_button("Learn more", color = "primary"), class_name = "lead"),
         ],
-        fluid=true,
-        class_name="py-3",
+        fluid = true,
+        class_name = "py-3",
     ),
-    class_name="p-3 bg-light rounded-3",
+    class_name = "p-3 bg-light rounded-3",
 )

--- a/docs/components_page/components/jumbotron/simple.py
+++ b/docs/components_page/components/jumbotron/simple.py
@@ -1,0 +1,26 @@
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+
+jumbotron = html.Div(
+    dbc.Container(
+        [
+            html.H1("Jumbotron", class_name="display-3"),
+            html.P(
+                "Use Containers to create a jumbotron to call attention to "
+                "featured content or information.",
+                class_name="lead",
+            ),
+            html.Hr(class_name="my-2"),
+            html.P(
+                "Use utility classes for typography and spacing to suit the "
+                "larger container."
+            ),
+            html.P(
+                dbc.Button("Learn more", color="primary"), class_name="lead"
+            ),
+        ],
+        fluid=True,
+        class_name="py-3",
+    ),
+    class_name="p-3 bg-light rounded-3",
+)


### PR DESCRIPTION
Based on the idea in #651, I've added examples of Jumbotron like components to the docs. Not sure they are in the right place at the moment, but they are at the same level as the components (that's where people are most likely to look for them).

The examples are based on the previous Jumbotron example, and those on here: [https://getbootstrap.com/docs/5.0/examples/jumbotron/](https://getbootstrap.com/docs/5.0/examples/jumbotron/)