### PR TITLE
Add deprecation warnings for removed components

### DIFF
--- a/dash_bootstrap_components/__init__.py
+++ b/dash_bootstrap_components/__init__.py
@@ -2,16 +2,15 @@
 import os
 import sys
 
-from dash_bootstrap_components import icons  # noqa
-from dash_bootstrap_components import themes  # noqa
-from dash_bootstrap_components import _components
+from dash_bootstrap_components import _components, icons, themes
 from dash_bootstrap_components._components import *  # noqa
 from dash_bootstrap_components._table import _generate_table_from_df
 from dash_bootstrap_components._version import __version__
 
-_current_path = os.path.dirname(os.path.abspath(__file__))
+__all__ = _components.__all__ + ["icons", "themes"]
 
-METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")
+_current_path = os.path.dirname(os.path.abspath(__file__))
+_METADATA_PATH = os.path.join(_current_path, "_components", "metadata.json")
 
 _js_dist = [
     {
@@ -19,9 +18,9 @@ _js_dist = [
             "_components/dash_bootstrap_components.min.js"
         ),
         "external_url": (
-            "https://unpkg.com/dash-bootstrap-components@{}"
+            f"https://unpkg.com/dash-bootstrap-components@{__version__}"
             "/dist/dash_bootstrap_components.min.js"
-        ).format(__version__),
+        ),
         "namespace": "dash_bootstrap_components",
     }
 ]
@@ -37,4 +36,45 @@ for _component_name in _components.__all__:
 
 sys.modules[__name__].Table.from_dataframe = classmethod(
     _generate_table_from_df
+)
+
+
+# TODO: when Python 3.6 support is dropped we can simplify this with PEP 562
+# https://www.python.org/dev/peps/pep-0562/
+class _V1DeprecationWarningWrapper:
+    def __init__(self, wrapped, deprecated):
+        self.wrapped = wrapped
+        self.deprecated = deprecated
+
+    def __getattr__(self, name):
+        if name in self.deprecated:
+            # TODO: update URL before release
+            raise AttributeError(
+                f"{name} was deprecated in dash-bootstrap-components version "
+                f"1.0.0. You are using {__version__}. For more details please "
+                "see the migration guide: "
+                "https://dbc-v1.herokuapp.com/migration-guide/"
+            )
+        return getattr(self.wrapped, name)
+
+    def __dir__(self):
+        # required for autocomplete. filter out os, and sys imports
+        return [
+            item
+            for item in self.wrapped.__dir__()
+            if item not in {"os", "sys"}
+        ]
+
+
+sys.modules[__name__] = _V1DeprecationWarningWrapper(
+    sys.modules[__name__],
+    [
+        "CardColumns",
+        "CardDeck",
+        "FormGroup",
+        "InputGroupAddon",
+        "Jumbotron",
+        "ListGroupItemHeading",
+        "ListGroupItemText",
+    ],
 )

--- a/docs/components_page/metadata.py
+++ b/docs/components_page/metadata.py
@@ -12,7 +12,7 @@ def get_component_metadata(component_path):
 
 @lru_cache(maxsize=1)
 def _load_metadata():
-    return _get_metadata(dbc.METADATA_PATH)
+    return _get_metadata(dbc._METADATA_PATH)
 
 
 def _get_metadata(metadata_path):


### PR DESCRIPTION
Added more informative error messages for deprecated components.

Also took the opportunity to clean up the autocomplete for the module. In particular imports (like `os` and `sys`) will no longer show up, and deprecated components will not tab-complete.

See #695 