### PR TITLE
Remove snake_case class_name from docs

### DIFF
--- a/docs/content/docs/icons.md
+++ b/docs/content/docs/icons.md
@@ -109,35 +109,35 @@ alerts = html.Div(
     [
         dbc.Alert(
             [
-                html.I(class_name="bi bi-info-circle-fill me-2"),
+                html.I(className="bi bi-info-circle-fill me-2"),
                 "An example info alert with an icon",
             ],
             color="info",
-            class_name="d-flex align-items-center",
+            className="d-flex align-items-center",
         ),
         dbc.Alert(
             [
-                html.I(class_name="bi bi-check-circle-fill me-2"),
+                html.I(className="bi bi-check-circle-fill me-2"),
                 "An example success alert with an icon",
             ],
             color="success",
-            class_name="d-flex align-items-center",
+            className="d-flex align-items-center",
         ),
         dbc.Alert(
             [
-                html.I(class_name="bi bi-exclamation-triangle-fill me-2"),
+                html.I(className="bi bi-exclamation-triangle-fill me-2"),
                 "An example warning alert with an icon",
             ],
             color="warning",
-            class_name="d-flex align-items-center",
+            className="d-flex align-items-center",
         ),
         dbc.Alert(
             [
-                html.I(class_name="bi bi-x-octagon-fill me-2"),
+                html.I(className="bi bi-x-octagon-fill me-2"),
                 "An example danger alert with an icon",
             ],
             color="danger",
-            class_name="d-flex align-items-center",
+            className="d-flex align-items-center",
         ),
     ]
 )
@@ -153,35 +153,35 @@ alerts <- htmlDiv(
   list(
     dbcAlert(
       list(
-        htmlI(class_name = "bi bi-info-circle-fill me-2"),
+        htmlI(className = "bi bi-info-circle-fill me-2"),
         "An example info alert with an icon"
       ),
       color = "info",
-      class_name = "d-flex align-items-center"
+      className = "d-flex align-items-center"
     ),
     dbcAlert(
       list(
-        htmlI(class_name = "bi bi-check-circle-fill me-2"),
+        htmlI(className = "bi bi-check-circle-fill me-2"),
         "An example success alert with an icon"
       ),
       color = "success",
-      class_name = "d-flex align-items-center"
+      className = "d-flex align-items-center"
     ),
     dbcAlert(
       list(
-        htmlI(class_name = "bi bi-exclamation-triangle-fill me-2"),
+        htmlI(className = "bi bi-exclamation-triangle-fill me-2"),
         "An example warning alert with an icon"
       ),
       color = "warning",
-      class_name = "d-flex align-items-center"
+      className = "d-flex align-items-center"
     ),
     dbcAlert(
       list(
-        htmlI(class_name = "bi bi-x-octagon-fill me-2"),
+        htmlI(className = "bi bi-x-octagon-fill me-2"),
         "An example danger alert with an icon"
       ),
       color = "danger",
-      class_name = "d-flex align-items-center"
+      className = "d-flex align-items-center"
     )
   )
 )
@@ -196,35 +196,35 @@ using DashBootstrapComponents, DashHtmlComponents
 alerts = html_div([
     dbc_alert(
         [
-            html_i(class_name = "bi bi-info-circle-fill me-2"),
+            html_i(className = "bi bi-info-circle-fill me-2"),
             "An example info alert with an icon",
         ],
         color = "info",
-        class_name = "d-flex align-items-center",
+        className = "d-flex align-items-center",
     ),
     dbc_alert(
         [
-            html_i(class_name = "bi bi-check-circle-fill me-2"),
+            html_i(className = "bi bi-check-circle-fill me-2"),
             "An example success alert with an icon",
         ],
         color = "success",
-        class_name = "d-flex align-items-center",
+        className = "d-flex align-items-center",
     ),
     dbc_alert(
         [
-            html_i(class_name = "bi bi-exclamation-triangle-fill me-2"),
+            html_i(className = "bi bi-exclamation-triangle-fill me-2"),
             "An example warning alert with an icon",
         ],
         color = "warning",
-        class_name = "d-flex align-items-center",
+        className = "d-flex align-items-center",
     ),
     dbc_alert(
         [
-            html_i(class_name = "bi bi-x-octagon-fill me-2"),
+            html_i(className = "bi bi-x-octagon-fill me-2"),
             "An example danger alert with an icon",
         ],
         color = "danger",
-        class_name = "d-flex align-items-center",
+        className = "d-flex align-items-center",
     ),
 ])
 ```

--- a/docs/content/docs/quickstart.md
+++ b/docs/content/docs/quickstart.md
@@ -139,7 +139,7 @@ app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
 
 app.layout = dbc.Container(
     dbc.Alert("Hello Bootstrap!", color="success"),
-    class_name="p-5",
+    className="p-5",
 )
 
 if __name__ == "__main__":
@@ -156,7 +156,7 @@ library(dashBootstrapComponents)
 app <- Dash$new(external_stylesheets = dbcThemes$BOOTSTRAP)
 
 app$layout(dbcContainer(dbcAlert("Hello Bootstrap!", color = "success"),
-                        class_name = "p-5"))
+                        className = "p-5"))
 
 app$run_server(showcase = TRUE)
 ```
@@ -171,7 +171,7 @@ app = dash(external_stylesheets=[dbc_themes.BOOTSTRAP])
 
 app.layout = dbc_container(
     dbc_alert("Hello Bootstrap!", color="success"),
-    class_name="p-5",
+    className="p-5",
 )
 
 run_server(app, "0.0.0.0", 8080)

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -65,7 +65,7 @@ app = dash.Dash(
 )
 
 app.layout = dbc.Alert(
-    "Hello, Bootstrap!", class_name="m-5"
+    "Hello, Bootstrap!", className="m-5"
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Missed a few examples when updating. Sticking with `className` until Dash adds support for `class_name`