### PR TITLE
Fix regression in DropdownMenu dismissal

### DIFF
--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -64,6 +64,11 @@ const DropdownMenu = props => {
             ? 'end'
             : direction
         }
+        onToggle={(show, event) => {
+          if (!event || event.source !== 'select') {
+            setDropdownOpen(show);
+          }
+        }}
         align={align_end ? 'end' : right ? 'end' : 'start'}
         {...omit(['setProps'], otherProps)}
         data-dash-is-loading={


### PR DESCRIPTION
This PR restores two properties of `DropdownMenu`:

- Menu will dismiss when user clicks outside the menu.
- Menu will dismiss if user presses escape key.

Resolves one of the issues documented in #750