### PR TITLE
Add select form feedback

### DIFF
--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -8,7 +8,14 @@ import RBFormSelect from 'react-bootstrap/FormSelect';
  * list of dictionaries with keys label, value and disabled.
  */
 const Select = props => {
-  const {className, class_name, html_size, ...otherProps} = props;
+  const {
+    className,
+    class_name,
+    html_size,
+    valid,
+    invalid,
+    ...otherProps
+  } = props;
 
   const handleChange = e => {
     if (props.setProps) {
@@ -29,6 +36,8 @@ const Select = props => {
         ],
         otherProps
       )}
+      isInvalid={invalid}
+      isValid={valid}
       onChange={handleChange}
       className={class_name || className}
       htmlSize={html_size}

--- a/src/components/input/__tests__/Select.test.js
+++ b/src/components/input/__tests__/Select.test.js
@@ -43,6 +43,14 @@ describe('Select', () => {
     expect(select).not.toHaveValue();
   });
 
+  test('sets validity using "valid" and "invalid" props', () => {
+    const validSelect = render(<Select valid />);
+    const invalidSelect = render(<Select invalid />);
+
+    expect(validSelect.container.firstChild).toHaveClass('is-valid');
+    expect(invalidSelect.container.firstChild).toHaveClass('is-invalid');
+  });
+
   test('dispatches value when selection is made and setProps is set', () => {
     const mockSetProps = jest.fn();
     const {


### PR DESCRIPTION
Issue raised #753 which identified that the `valid` and `invalid` props were not being passed correctly to the underlying component. This is because react-bootstrap uses `isInvalid` and `isValid` instead.

This resolves this issue. 