### PR TITLE
Fix tab tooltip issue

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -52,6 +52,7 @@ const Tabs = props => {
       const active = active_tab === tabId;
       return (
         <RBNav.Item
+          id={childProps.id}
           key={tabId}
           style={
             active
@@ -100,6 +101,7 @@ const Tabs = props => {
       const {
         children,
         tab_id,
+        id,
         label,
         tab_style,
         active_tab_style,


### PR DESCRIPTION
Issue #752 resolution.

Ensure that id is passed to the tab is passed to the underlying html component to allow tooltip association.