### PR TITLE
Fixes default button color in docs

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -145,7 +145,7 @@ Button.propTypes = {
 
   /**
    * Button color, options: primary, secondary, success, info, warning, danger,
-   * link. Default: secondary.
+   * link. Default: primary.
    */
   color: PropTypes.string,
 

--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -204,7 +204,7 @@ DropdownMenu.propTypes = {
    * Set the color of the DropdownMenu toggle. Available options are: 'primary',
    * 'secondary', 'success', 'warning', 'danger', 'info', 'link' or any valid CSS
    * color of your choice (e.g. a hex code, a decimal code or a CSS color name)
-   * Default: 'secondary'
+   * Default: 'primary'
    */
   color: PropTypes.string,
 


### PR DESCRIPTION
Docs for the `button` component (https://dash-bootstrap-components.opensource.faculty.ai/docs/components/button/) still show the default color as "secondary", although that changed to "primary" in Bootstrap5 and the migration guide (https://dash-bootstrap-components.opensource.faculty.ai/migration-guide/) shows that.