### PR TITLE
Prerelease 1.0.2-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.2-dev"
+__version__ = "1.0.2-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.0.2-dev",
+  "version": "1.0.2-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.0.2-dev"
+    assert __version__ == "1.0.2-rc1"


### PR DESCRIPTION
This release updates CDN links to use Bootstrap 5.1.3 and fixes a few bugs. Please continue to report bugs on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues)!

### Changed

- Links in the `themes` module now use Bootstrap 5.1.3 ([PR 789](https://github.com/facultyai/dash-bootstrap-components/pull/789))

### Added

- Added `autohide` prop to `Tooltip` and `Popover` when using the `hover` trigger. When set to `True`, the `Popover` / `Tooltip` will hide if the mouse is moved over the content ([PR 788](https://github.com/facultyai/dash-bootstrap-components/pull/788))

### Fixed

- `Popover` with trigger `hover` will not dismiss if mouse is moved over the content ([PR 788](https://github.com/facultyai/dash-bootstrap-components/pull/788))
- Resolved bug where `Tooltip` could get stuck open when moused over quickly ([PR 788](https://github.com/facultyai/dash-bootstrap-components/pull/788))