### PR TITLE
Bugfix: tab should show pointer on mouse over

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -74,12 +74,11 @@ const Tabs = props => {
                   childProps.activeLabelClassName),
               {active}
             )}
-            // href="#"
-            style={
-              active
-                ? {...childProps.label_style, ...childProps.active_label_style}
-                : childProps.label_style
-            }
+            style={{
+              ...(active && childProps.active_label_style),
+              ...(!childProps.disabled && {cursor: 'pointer'}),
+              ...childProps.label_style
+            }}
             disabled={childProps.disabled}
             onClick={() => {
               if (!childProps.disabled) {


### PR DESCRIPTION
This PR ensures that the cursor shows as a pointer on tabs.

cf. #796 