### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     services:
       hub:
         image: selenium/hub:3.141.59-gold
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != '3.8'
         uses: actions/setup-python@v1

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ def format_(session):
     session.run("isort", *SOURCES)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def test(session):
     session.install("pytest")
     session.install("dash[testing]>=2.0.0")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ GITHUB_URL = "https://github.com/facultyai/dash-bootstrap-components/"
 
 
 def _get_version():
-    """ Get version by parsing _version programmatically """
+    """Get version by parsing _version programmatically"""
     version_ns = {}
     with open(
         os.path.join(HERE, "dash_bootstrap_components", "_version.py")
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     extras_require={"pandas": ["numpy", "pandas"]},
     python_requires=">=3.6, <4",


### PR DESCRIPTION
Python 3.10 was supported implicitly, but this PR adds testing and the corresponding trove classifier.

Closes #838 