### PR TITLE
Allow Select to be cleared with None

### DIFF
--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -14,6 +14,7 @@ const Select = props => {
     html_size,
     valid,
     invalid,
+    value,
     ...otherProps
   } = props;
 
@@ -41,6 +42,7 @@ const Select = props => {
       onChange={handleChange}
       className={class_name || className}
       htmlSize={html_size}
+      value={value || ''}
     >
       <option value="" disabled hidden>
         {props.placeholder}

--- a/src/components/input/__tests__/Select.test.js
+++ b/src/components/input/__tests__/Select.test.js
@@ -43,6 +43,23 @@ describe('Select', () => {
     expect(select).not.toHaveValue();
   });
 
+  test('null will clear value', () => {
+    const {
+      container: {firstChild: select}
+    } = render(
+      <Select
+        id="test-select"
+        options={[
+          {label: 'Item 1', value: '1'},
+          {label: 'Item 2', value: '2'}
+        ]}
+        value={null}
+      />
+    );
+
+    expect(select).not.toHaveValue();
+  });
+
   test('sets validity using "valid" and "invalid" props', () => {
     const validSelect = render(<Select valid />);
     const invalidSelect = render(<Select invalid />);


### PR DESCRIPTION
Previously to clear a Select component from a callback you would have to set the value to the empty string. This PR ensures that setting the value to `None` will also work.

Cf. #829 
