### PR TITLE
Prerelease 1.1.0-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0-dev"
+__version__ = "1.1.0-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.1.0-dev",
+  "version": "1.1.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.1.0-dev"
+    assert __version__ == "1.1.0-rc1"


### PR DESCRIPTION
This is a release candidate for version 1.1.0.

### Added

- Add `readonly` prop to `Input` component ([PR 833](https://github.com/facultyai/dash-bootstrap-components/pull/833))
- Add `always_open` prop to `Accordion`. When set to `True`, opening one section of the accordion does not close any currently open sections ([PR 840](https://github.com/facultyai/dash-bootstrap-components/pull/840))
- dash-bootstrap-components now explicitly supports Python 3.10 ([PR 841](https://github.com/facultyai/dash-bootstrap-components/pull/841))

### Fixed

- Allow arbitrary colors to be passed to `color` prop of `Progress` ([PR 835](https://github.com/facultyai/dash-bootstrap-components/pull/835))
- `contentClassName` in `Modal` has been fixed, previously it was not passing the class names on to the relevant elements ([PR 839](https://github.com/facultyai/dash-bootstrap-components/pull/839))
- `Select` can now be cleared by returning `None` from a callback  ([PR 842](https://github.com/facultyai/dash-bootstrap-components/pull/842))

### Changed
- Updated CDN links for FontAwesome and Bootstrap Icons in the `icons` submodule. FontAwesome now uses version 6.1.1, Bootstrap Icons uses version 1.8.1 ([PR 837](https://github.com/facultyai/dash-bootstrap-components/pull/837))