### PR TITLE
Textarea debounce bug

### DIFF
--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -57,14 +57,14 @@ const Textarea = props => {
     }
   };
 
-  const onBlur = () => {
+  const onBlur = e => {
     if (setProps) {
       const payload = {
         n_blur: n_blur + 1,
         n_blur_timestamp: Date.now()
       };
       if (debounce) {
-        payload.value = value;
+        payload.value = e.target.value;
       }
       setProps(payload);
     }
@@ -77,7 +77,7 @@ const Textarea = props => {
         n_submit_timestamp: Date.now()
       };
       if (debounce) {
-        payload.value = value;
+        payload.value = e.target.value;
       }
       setProps(payload);
     }


### PR DESCRIPTION
The `value` prop in the `Textarea` was not being updated on blur or submit if `debounce` was set to true. This bug was missed because the tests were not actually checking for a change in `value`.

Reported in #856 