### PR TITLE
Tooltip enhancements

### DIFF
--- a/docs/components_page/components/tooltip.md
+++ b/docs/components_page/components/tooltip.md
@@ -17,4 +17,10 @@ Use the `placement` argument to control the placement of the tooltip. The basic 
 
 {{example:components/tooltip/placement.py:tooltips}}
 
+## Controlling the Tooltip with callbacks
+
+The tooltip's visibility can be controlled with callbacks much like a `Popover` component. Simply set the desired value of `is_open` in a callback. If you are manually controlling the value of `is_open`, you may wish to also set `trigger=None`. By default the `Tooltip` will show when the target element is hovered or focused.
+
+{{example:components/tooltip/tooltip_callback.py:tooltip}}
+
 {{apidoc:src/components/Tooltip.js}}

--- a/docs/components_page/components/tooltip/tooltip_callback.py
+++ b/docs/components_page/components/tooltip/tooltip_callback.py
@@ -1,0 +1,33 @@
+import dash_bootstrap_components as dbc
+from dash import Input, Output, State, html
+
+tooltip = html.Div(
+    [
+        dbc.Button(
+            "Toggle",
+            id="toggle",
+            color="success",
+            className="me-4",
+            n_clicks=0,
+        ),
+        dbc.Button("Target", id="target", color="danger", n_clicks=0),
+        dbc.Tooltip(
+            "This is a tooltip",
+            id="tooltip",
+            is_open=False,
+            target="target",
+            trigger=None,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("tooltip", "is_open"),
+    [Input("toggle", "n_clicks")],
+    [State("tooltip", "is_open")],
+)
+def toggle_tooltip(n, is_open):
+    if n:
+        return not is_open
+    return is_open

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ exclude =
     docs/components_page/components/toast/auto_dismiss.py,
     docs/components_page/components/toast/icon_dismiss.py,
     docs/components_page/components/toast/position.py,
+    docs/components_page/components/tooltip/tooltip_callback.py,
 ignore = E203, W503
 
 [isort]

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -20,6 +20,7 @@ const Tooltip = props => {
     className,
     class_name,
     style,
+    fade,
     ...otherProps
   } = props;
 
@@ -30,6 +31,7 @@ const Tooltip = props => {
       }
       {...omit(['setProps'], otherProps)}
       trigger="hover focus"
+      transition={fade}
     >
       <TooltipTemplate
         id={id}
@@ -46,7 +48,8 @@ Tooltip.defaultProps = {
   delay: {show: 0, hide: 50},
   placement: 'auto',
   flip: true,
-  autohide: true
+  autohide: true,
+  fade: true
 };
 
 Tooltip.propTypes = {
@@ -127,6 +130,12 @@ Tooltip.propTypes = {
    * Optionally hide tooltip when hovering over tooltip content - default True.
    */
   autohide: PropTypes.bool,
+
+  /**
+   * If True, a fade animation will be applied when `is_open` is toggled. If
+   * False the Alert will simply appear and disappear.
+   */
+  fade: PropTypes.bool,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -16,6 +16,7 @@ const Tooltip = props => {
   const {
     id,
     children,
+    is_open,
     loading_state,
     className,
     class_name,
@@ -29,8 +30,8 @@ const Tooltip = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...omit(['setProps'], otherProps)}
-      trigger="hover focus"
+      defaultShow={is_open}
+      {...otherProps}
       transition={fade}
     >
       <TooltipTemplate
@@ -49,7 +50,8 @@ Tooltip.defaultProps = {
   placement: 'auto',
   flip: true,
   autohide: true,
-  fade: true
+  fade: true,
+  trigger: 'hover focus'
 };
 
 Tooltip.propTypes = {
@@ -136,6 +138,27 @@ Tooltip.propTypes = {
    * False the Alert will simply appear and disappear.
    */
   fade: PropTypes.bool,
+
+  /**
+   * Space separated list of triggers (e.g. "click hover focus legacy"). These
+   * specify ways in which the target component can toggle the tooltip. If
+   * omitted you must toggle the tooltip yourself using callbacks. Options
+   * are:
+   * - "click": toggles the popover when the target is clicked.
+   * - "hover": toggles the popover when the target is hovered over with the
+   * cursor.
+   * - "focus": toggles the popover when the target receives focus
+   * - "legacy": toggles the popover when the target is clicked, but will also
+   * dismiss the popover when the user clicks outside of the popover.
+   *
+   * Default is "hover focus"
+   */
+  trigger: PropTypes.string,
+
+  /**
+   * Whether the Tooltip is open or not.
+   */
+  is_open: PropTypes.bool,
 
   /**
    * Object that holds the loading state object coming from dash-renderer


### PR DESCRIPTION
Expanding the functionality of `Tooltip`. There are three new props:

- `fade` - much like the `Alert` component, this can be used to disable the fade animation when the tooltip shows
- `trigger` - like the `Popover` component, this can be used to set automatic triggers for the `Tooltip`
- `is_open` - the visibility of `Tooltip` can now be controlled with a callback

As suggested in #857 