### PR TITLE
Persistence improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.1.0-dev",
+  "version": "1.2.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dash-bootstrap-components",
-      "version": "1.1.0-dev",
+      "version": "1.2.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@plotly/dash-component-plugins": "^1.2.0",
@@ -3581,9 +3581,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -14455,9 +14455,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"

--- a/src/components/alert/Alert.js
+++ b/src/components/alert/Alert.js
@@ -55,7 +55,10 @@ const Alert = props => {
       className={class_name || className}
       transition={fade}
       style={!isBootstrapColor ? {backgroundColor: color, ...style} : style}
-      {...omit(['setProps'], otherProps)}
+      {...omit(
+        ['persistence', 'persisted_props', 'persistence_type', 'setProps'],
+        otherProps
+      )}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
@@ -68,7 +71,9 @@ const Alert = props => {
 Alert.defaultProps = {
   color: 'success',
   is_open: true,
-  duration: null
+  duration: null,
+  persisted_props: ['is_open'],
+  persistence_type: 'local'
 };
 
 Alert.propTypes = {
@@ -153,7 +158,36 @@ Alert.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['is_open'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Alert;

--- a/src/components/carousel/Carousel.js
+++ b/src/components/carousel/Carousel.js
@@ -55,7 +55,10 @@ const Carousel = props => {
         activeIndex={active_index}
         onSelect={idx => setProps({active_index: idx})}
         interval={interval || null}
-        {...omit(['setProps'], otherProps)}
+        {...omit(
+          ['persistence', 'persisted_props', 'persistence_type', 'setProps'],
+          otherProps
+        )}
       >
         {slides}
       </RBCarousel>
@@ -66,7 +69,9 @@ const Carousel = props => {
 Carousel.defaultProps = {
   active_index: 0,
   controls: true,
-  indicators: true
+  indicators: true,
+  persisted_props: ['active_index'],
+  persistence_type: 'local'
 };
 
 Carousel.propTypes = {
@@ -201,6 +206,35 @@ Carousel.propTypes = {
      */
     component_name: PropTypes.string
   }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['active_index'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 
   /**
    * Dash-assigned callback that gets fired when the value changes.

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {omit} from 'ramda';
 
 import {PopoverTemplate} from '../../private/OverlayTemplates';
 import Overlay from '../../private/Overlay';
@@ -52,7 +53,10 @@ const Popover = props => {
       }
       defaultShow={is_open}
       popperConfig={popperConfig}
-      {...otherProps}
+      {...omit(
+        ['persistence', 'persisted_props', 'persistence_type'],
+        otherProps
+      )}
     >
       <PopoverTemplate
         // to ensure proper backwards compatibility, the toggle function is only
@@ -73,7 +77,9 @@ Popover.defaultProps = {
   delay: {show: 0, hide: 50},
   placement: 'right',
   flip: true,
-  autohide: false
+  autohide: false,
+  persisted_props: ['is_open'],
+  persistence_type: 'local'
 };
 
 Popover.propTypes = {
@@ -230,7 +236,36 @@ Popover.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['is_open'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Popover;

--- a/src/components/popover/__tests__/Popover.test.js
+++ b/src/components/popover/__tests__/Popover.test.js
@@ -6,6 +6,8 @@ import React from 'react';
 import {render} from '@testing-library/react';
 import Popover from '../Popover';
 
+jest.useFakeTimers();
+
 // TODO - Add test for offset
 
 describe('Popover', () => {
@@ -38,6 +40,8 @@ describe('Popover', () => {
       container: document.body.appendChild(div)
     });
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('.popover.show')).not.toBe(null);
   });
 
@@ -46,6 +50,8 @@ describe('Popover', () => {
       container: document.body.appendChild(div)
     });
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('.popover.show')).toBe(null);
   });
 
@@ -53,6 +59,8 @@ describe('Popover', () => {
     render(<Popover target="test-target" is_open={true} />, {
       container: document.body.appendChild(div)
     });
+
+    jest.runAllTimers();
 
     expect(document.body.querySelector('.popover.show')).not.toBe(null);
   });
@@ -65,6 +73,8 @@ describe('Popover', () => {
       {container: document.body.appendChild(div)}
     );
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('.popover')).toHaveTextContent(
       'Popover content'
     );
@@ -75,6 +85,8 @@ describe('Popover', () => {
       container: document.body.appendChild(div)
     });
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('.popover-arrow')).not.toBe(null);
   });
 
@@ -82,6 +94,8 @@ describe('Popover', () => {
     render(<Popover target="test-target" is_open hide_arrow />, {
       container: document.body.appendChild(div)
     });
+
+    jest.runAllTimers();
 
     expect(document.body.querySelector('.popover-arrow')).toBe(null);
   });
@@ -96,6 +110,8 @@ describe('Popover', () => {
       }
     );
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('.popover-body')).not.toBe(null);
   });
 
@@ -108,6 +124,8 @@ describe('Popover', () => {
         container: document.body.appendChild(div)
       }
     );
+
+    jest.runAllTimers();
 
     expect(document.body.querySelector('.popover-body')).toBe(null);
   });

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -241,7 +241,7 @@ Tabs.propTypes = {
 
   /**
    * Properties whose user interactions will persist after refreshing the
-   * component or the page. Since only `value` is allowed this prop can
+   * component or the page. Since only `active_tab` is allowed this prop can
    * normally be ignored.
    */
   persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['active_tab'])),

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -64,7 +64,16 @@ const Toast = props => {
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
-      {...omit(['n_dismiss_timestamp'], otherProps)}
+      {...omit(
+        [
+          'n_dismiss_timestamp',
+          'persistence',
+          'persisted_props',
+          'persistence_type',
+          'setProps'
+        ],
+        otherProps
+      )}
     >
       <RBToast.Header
         style={header_style}
@@ -102,7 +111,9 @@ Toast.defaultProps = {
   is_open: true,
   n_dismiss: 0,
   n_dismiss_timestamp: -1,
-  dismissable: false
+  dismissable: false,
+  persisted_props: ['is_open'],
+  persistence_type: 'local'
 };
 
 Toast.propTypes = {
@@ -252,7 +263,36 @@ Toast.propTypes = {
      * Holds the name of the component that is loading
      */
     component_name: PropTypes.string
-  })
+  }),
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number
+  ]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['is_open'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default Toast;

--- a/src/private/Overlay.js
+++ b/src/private/Overlay.js
@@ -164,7 +164,7 @@ const Overlay = ({
 
   // Update the isOpen state, when defaultShow changes
   useEffect(() => {
-    setIsOpen(defaultShow);
+    setTimeout(() => setIsOpen(defaultShow), 50);
   }, [defaultShow]);
 
   // If legacy is a trigger, then need to set root close to true to allow

--- a/src/private/__tests__/Overlay.test.js
+++ b/src/private/__tests__/Overlay.test.js
@@ -59,6 +59,8 @@ describe('Overlay with dict id', () => {
       }
     );
 
+    jest.runAllTimers();
+
     expect(document.body.querySelector('#content')).not.toBe(null);
   });
 });

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -3,6 +3,7 @@ from dash.dependencies import Input, Output
 from dash_bootstrap_components import NavLink
 from dash import dcc, html
 from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.common.by import By
 
 
 def test_dbnl001_auto_active(dash_duo):
@@ -118,7 +119,7 @@ def test_dbnl_002_manual_active(dash_duo):
     # wait for callback to update page
     WebDriverWait(dash_duo.driver, timeout=10).until(
         lambda d: "active"
-        in d.find_element_by_id("page-1-link").get_attribute("class")
+        in d.find_element(By.ID, "page-1-link").get_attribute("class")
     )
 
     assert "active" in dash_duo.wait_for_element_by_id(
@@ -136,7 +137,7 @@ def test_dbnl_002_manual_active(dash_duo):
     # wait for callback to update page
     WebDriverWait(dash_duo.driver, timeout=10).until(
         lambda d: "active"
-        not in d.find_element_by_id("page-1-link").get_attribute("class")
+        not in d.find_element(By.ID, "page-1-link").get_attribute("class")
     )
 
     assert "active" not in dash_duo.wait_for_element_by_id(


### PR DESCRIPTION
This PR adds support for `persistence` to `Alert`, `Carousel`, `Popover`, and `Toast`. It also fixes a bug that ensures the `Popover` renders initially if the default value of `is_open` is `True`.