### PR TITLE
Prerelease 1.2.0-rc3

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.0-dev"
+__version__ = "1.2.0-rc3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.2.0-dev",
+  "version": "1.2.0-rc3",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.2.0-dev"
+    assert __version__ == "1.2.0-rc3"


### PR DESCRIPTION
This is a release candidate for dash-bootstrap-components 1.2.0

### Added

- `Tooltip` can now be shown and hidden from callbacks via the new `is_open` prop ([PR 861](https://github.com/facultyai/dash-bootstrap-components/pull/861))
- Added `trigger` prop to `Tooltip` which behaves like `trigger` prop of `Popover`, allowing users to control what causes the tooltip to show ([PR 861](https://github.com/facultyai/dash-bootstrap-components/pull/861))
- Added `fade` prop to `Tooltip`, which behaves like `fade` prop of `Alert`, allowing users to control whether the tooltip shows and hides with a fade animation or not (([PR 861](https://github.com/facultyai/dash-bootstrap-components/pull/861))
- Add `persistence` prop to `Alert`, `Carousel`, `Popover`, `Toast` (([PR 872](https://github.com/facultyai/dash-bootstrap-components/pull/872))

### Fixed

- Fixed bug in `Textarea`. Now `setProps` is called with the correct value when `debounce=True` on blur and submit event ([PR 858](https://github.com/facultyai/dash-bootstrap-components/pull/858))
- `zindex` / `zIndex` argument in `Modal` is now applied correctly ([PR 869](https://github.com/facultyai/dash-bootstrap-components/pull/869))
- `Popover` displays on start-up when default value of `is_open` is `True` (([PR 872](https://github.com/facultyai/dash-bootstrap-components/pull/872))