### PR TITLE
Forward undefined to target props instead of bool

### DIFF
--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -52,8 +52,6 @@ const DropdownMenuItem = props => {
   return (
     <RBDropdown.Item
       as={useLink ? Link : 'button'}
-      // don't pass href if disabled otherwise reactstrap renders item
-      // as link and the cursor becomes a pointer on hover
       href={useLink ? href : undefined}
       disabled={disabled}
       target={useLink ? target : undefined}

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -54,9 +54,9 @@ const DropdownMenuItem = props => {
       as={useLink ? Link : 'button'}
       // don't pass href if disabled otherwise reactstrap renders item
       // as link and the cursor becomes a pointer on hover
-      href={disabled ? null : href}
+      href={useLink ? href : undefined}
       disabled={disabled}
-      target={useLink && target}
+      target={useLink ? target : undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
       data-dash-is-loading={

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -12,6 +12,7 @@ const ListGroupItem = props => {
   let {
     children,
     disabled,
+    href,
     loading_state,
     target,
     n_clicks,
@@ -32,13 +33,14 @@ const ListGroupItem = props => {
     }
   };
   const isBootstrapColor = bootstrapColors.has(color);
-  const useLink = props.href && !disabled;
+  const useLink = href && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
 
   return (
     <RBListGroupItem
       as={useLink ? Link : 'li'}
-      target={useLink && target}
+      href={href}
+      target={useLink ? target : undefined}
       disabled={disabled}
       variant={isBootstrapColor ? color : null}
       style={!isBootstrapColor ? {backgroundColor: color, ...style} : style}


### PR DESCRIPTION
_react-dom_ complains with a warning if it receives booleans for non-boolean DOM properties (see <https://github.com/facebook/react/blob/main/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js#L186-L190>).

This passes `undefined` to the `target` props instead of `false to fix the warning.

<img width="1061" alt="CleanShot 2022-07-13 at 15 12 30@2x" src="https://user-images.githubusercontent.com/245443/178741874-fc3499c4-c37b-45d4-9e9a-5d1cfe8fcee5.png">