### PR TITLE
Allow DropdownMenu toggles to be styled as links

### DIFF
--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -40,7 +40,7 @@ const DropdownMenu = props => {
   } = props;
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const isBootstrapColor = bootstrapColors.has(color) || color === "link";
+  const isBootstrapColor = bootstrapColors.has(color) || color === 'link';
   const toggle = () => {
     if (!disabled) {
       setDropdownOpen(!dropdownOpen);

--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -40,7 +40,7 @@ const DropdownMenu = props => {
   } = props;
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const isBootstrapColor = bootstrapColors.has(color);
+  const isBootstrapColor = bootstrapColors.has(color) || color === "link";
   const toggle = () => {
     if (!disabled) {
       setDropdownOpen(!dropdownOpen);


### PR DESCRIPTION
DropdownMenu toggles are essentially Bootstrap buttons, and hence it should be possible to use the `link` color variant. Due to a bug reported in #879 this wasn't working properly. This PR fixes that.