### PR TITLE
Prerelease 1.2.1-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.1-dev"
+__version__ = "1.2.1-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.2.1-dev",
+  "version": "1.2.1-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.2.1-dev"
+    assert __version__ == "1.2.1-rc1"


### PR DESCRIPTION
This is a pre-release candidate for version 1.2.1 of dash-bootstrap-components. This is a patch release containing bug fixes but no new features.

### Fixed

- Suppress console errors originating from `DropdownMenu` ([PR 878](https://github.com/facultyai/dash-bootstrap-components/pull/878))
- Allow `DropdownMenu` toggle to be rendered as a link ([PR 884](https://github.com/facultyai/dash-bootstrap-components/pull/884))
