### PR TITLE
Drop Python 3.6 from tests

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -28,10 +28,10 @@ jobs:
           node-version: 12.x
       - name: Install dependencies
         run: npm ci
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Dash
         run: python -m pip install -r requirements-dev.txt
       - name: Build dash-bootstrap-components
@@ -57,6 +57,6 @@ jobs:
       - name: Test Julia installation
         run: julia -e 'using Dash, DashBootstrapComponents, HTTP;'
       - name: Install nox
-        run: python3.8 -m pip install -U nox
+        run: python3.10 -m pip install -U nox
       - name: Test R and Julia docs snippets
         run: nox -s doctest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt
@@ -100,10 +100,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
           node-version: 12.x
       - name: Install dependencies
         run: npm ci
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install Dash
         run: python -m pip install -r requirements-dev.txt
       - name: Build dash-bootstrap-components
@@ -51,7 +51,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     services:
       hub:
         image: selenium/hub:3.141.59-gold
@@ -62,19 +62,19 @@ jobs:
           HUB_PORT: 4444
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Set up Python ${{ matrix.python-version }}
-        if: matrix.python-version != '3.8'
+        if: matrix.python-version != '3.10'
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install nox
-        run: python3.8 -m pip install -U nox
+        run: python3.10 -m pip install -U nox
       - name: Lint Python source
-        if: matrix.python-version == 3.8
+        if: matrix.python-version == '3.10'
         run: nox -s lint
       - uses: actions/download-artifact@v2
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ def format_(session):
     session.run("isort", *SOURCES)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     session.install("pytest")
     session.install("dash[testing]>=2.0.0")

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ setup(
     classifiers=[
         "Framework :: Dash",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     extras_require={"pandas": ["numpy", "pandas"]},
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
 )


### PR DESCRIPTION
Python 3.6 is EOL, this PR drops it from our tests and drops official support for it.