### PR TITLE
Prerelease 1.3.0-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.2-dev"
+__version__ = "1.3.0-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.2.2-dev",
+  "version": "1.3.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.2.2-dev"
+    assert __version__ == "1.3.0-rc1"


### PR DESCRIPTION
This is a release candidate for dash-bootstrap-components 1.2.0

### Added

- Add shorthand syntax for specifying options in `Checklist`, `RadioItems`, `Select` to mimic dash-core-components (([PR 894](https://github.com/facultyai/dash-bootstrap-components/pull/894))
- Add `numbered` prop to `ListGroup` for numbered list group support (([PR 895](https://github.com/facultyai/dash-bootstrap-components/pull/895))
- Add support for horizontal collapses with `horizontal` prop in `Collapse` component (([PR 896](https://github.com/facultyai/dash-bootstrap-components/pull/896))
- Add new `Stack` component for vertical layouts (([PR 897](https://github.com/facultyai/dash-bootstrap-components/pull/897))
- Add new `Placeholder` component which can be used as a loading component also (([PR 899](https://github.com/facultyai/dash-bootstrap-components/pull/899))
- Accept Dash components as arguments to `DropdownMenu.label`, `NavbarSimple.brand` and `Toast.header` (([PR 917](https://github.com/facultyai/dash-bootstrap-components/pull/917))
- Expose `rel` prop in `Button` when used as a link (([PR 921](https://github.com/facultyai/dash-bootstrap-components/pull/921))

### Fixed

- Fixed a recursion error that could arise when pickling dash-bootstrap-components ([PR 918](https://github.com/facultyai/dash-bootstrap-components/pull/918))
- Fixed navigation bug when using auto-dismissing `Toast` (([PR 920](https://github.com/facultyai/dash-bootstrap-components/pull/920))

### Changed

- Update to Bootstrap 5.2.3 (([PR 916](https://github.com/facultyai/dash-bootstrap-components/pull/916))
- Drop support for Python 3.6 (([PR 913](https://github.com/facultyai/dash-bootstrap-components/pull/913))