### PR TITLE
Prerelease 1.3.1-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.1-dev"
+__version__ = "1.3.1-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.3.1-dev",
+  "version": "1.3.1-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.3.1-dev"
+    assert __version__ == "1.3.1-rc1"


### PR DESCRIPTION
This is a patch release of dash-bootstrap-components. This version contains bug fixes but no new features. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Fixed

- Fixed an issue where `pylint` would fail to recognise `dbc.Table.from_dataframe` ([PR 926](https://github.com/facultyai/dash-bootstrap-components/pull/926))