### PR TITLE
Prerelease 1.3.2-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.3.2-dev"
+__version__ = "1.3.2-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.3.2-dev",
+  "version": "1.3.2-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.3.2-dev"
+    assert __version__ == "1.3.2-rc1"


### PR DESCRIPTION
This is a patch release of dash-bootstrap-components. This version contains bug fixes but no new features. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Fixed

- Ensure ids in `dbc.Tab` and `dbc.AccordionItem` are stringified before components are rendered ([PR 937](https://github.com/facultyai/dash-bootstrap-components/pull/937))
- Allow `Offcanvas.title` to be an arbitrary dash component ([PR 938](https://github.com/facultyai/dash-bootstrap-components/pull/938/files))