### PR TITLE
Components as props in labels

### DIFF
--- a/dash_bootstrap_components/icons.py
+++ b/dash_bootstrap_components/icons.py
@@ -1,5 +1,5 @@
 BOOTSTRAP = (
-    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/"
+    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/"
     "font/bootstrap-icons.css"
 )
-FONT_AWESOME = "https://use.fontawesome.com/releases/v6.1.1/css/all.css"
+FONT_AWESOME = "https://use.fontawesome.com/releases/v6.3.0/css/all.css"

--- a/docs/components_page/components/input.md
+++ b/docs/components_page/components/input.md
@@ -108,6 +108,13 @@ If you need more granular control over checkboxes and radio buttons, you can als
 
 {{example:components/input/radio_check_standalone.py:standalone_radio_check}}
 
+## Components in labels
+
+You can include components in labels for `Checklist`, `RadioItems`, `Checkbox`, `RadioButton`, and  `Switch`.
+
+{{example:components/input/components_in_labels.py:components_in_labels}}
+
+
 ## Color picker
 
 When using `Input` with `type="color"`, the user may specify a color, either by using a visual color picker or by entering the color in a text field in #rrggbb format.

--- a/docs/components_page/components/input/components_in_labels.py
+++ b/docs/components_page/components/input/components_in_labels.py
@@ -1,5 +1,5 @@
 import dash_bootstrap_components as dbc
-from dash import Dash, html
+from dash import html
 
 flights = html.Div([html.I(className="bi bi-airplane pe-1"), "Flights"])
 car = html.Div([html.I(className="bi bi-car-front pe-1"), "Rental Car"])

--- a/docs/components_page/components/input/components_in_labels.py
+++ b/docs/components_page/components/input/components_in_labels.py
@@ -1,6 +1,5 @@
-from dash import Dash, html
 import dash_bootstrap_components as dbc
-
+from dash import Dash, html
 
 flights = html.Div([html.I(className="bi bi-airplane pe-1"), "Flights"])
 car = html.Div([html.I(className="bi bi-car-front pe-1"), "Rental Car"])

--- a/docs/components_page/components/input/components_in_labels.py
+++ b/docs/components_page/components/input/components_in_labels.py
@@ -1,9 +1,10 @@
 from dash import Dash, html
 import dash_bootstrap_components as dbc
 
-flights = html.Div([html.Div(className="fa fa-plane pe-1"), "Flights"])
-car = html.Div([html.Div(className="fa fa-car pe-1"), "Rental Car"])
-hotel = html.Div([html.Div(className="fa fa-hotel pe-1"), "Hotel"])
+
+flights = html.Div([html.I(className="bi bi-airplane pe-1"), "Flights"])
+car = html.Div([html.I(className="bi bi-car-front pe-1"), "Rental Car"])
+hotel = html.Div([html.I(className="bi bi-house pe-1"), "Hotel"])
 
 radioitems = html.Div(
     [

--- a/docs/components_page/components/input/components_in_labels.py
+++ b/docs/components_page/components/input/components_in_labels.py
@@ -1,0 +1,31 @@
+from dash import Dash, html
+import dash_bootstrap_components as dbc
+
+flights = html.Div([html.Div(className="fa fa-plane pe-1"), "Flights"])
+car = html.Div([html.Div(className="fa fa-car pe-1"), "Rental Car"])
+hotel = html.Div([html.Div(className="fa fa-hotel pe-1"), "Hotel"])
+
+radioitems = html.Div(
+    [
+        dbc.Label("Booking"),
+        dbc.RadioItems(
+            options=[
+                {"label": flights, "value": 1},
+                {"label": car, "value": 2},
+                {"label": hotel, "value": 3},
+            ],
+            value=1,
+            id="radioitems-input",
+        ),
+    ]
+)
+
+checkbox = dbc.Checkbox(
+    id="standalone-checkbox",
+    label=html.Div(
+        ["I agree to the ", html.A("Terms and Conditions", href="#")]
+    ),
+    value=False,
+)
+
+components_in_labels = html.Div([radioitems, html.Hr(), checkbox])

--- a/docs/templates/partials/head.html
+++ b/docs/templates/partials/head.html
@@ -17,5 +17,5 @@
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css"
 />

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,7 @@ SOURCES = [
     "dash_bootstrap_components",
     "docs",
     "examples",
+    "tests",
     "noxfile.py",
     "tasks.py",
 ]

--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -125,7 +125,7 @@ Checkbox.propTypes = {
   /**
    * The label of the <input> element
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * The id of the label

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -190,8 +190,7 @@ Checklist.propTypes = {
         /**
          * The checkbox's label
          */
-        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
+        label: PropTypes.node.isRequired,
 
         /**
          * The value of the checkbox. This value corresponds to the items

--- a/src/components/input/RadioButton.js
+++ b/src/components/input/RadioButton.js
@@ -126,7 +126,7 @@ RadioButton.propTypes = {
   /**
    * The label of the <input> element
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * The id of the label

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -184,8 +184,7 @@ RadioItems.propTypes = {
         /**
          * The radio item's label
          */
-        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
+        label: PropTypes.node.isRequired,
 
         /**
          * The value of the radio item. This value corresponds to the items

--- a/src/components/input/Switch.js
+++ b/src/components/input/Switch.js
@@ -125,7 +125,7 @@ Switch.propTypes = {
   /**
    * The label of the <input> element
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * The id of the label

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -37,4 +37,4 @@ def test_mdcap001_components_as_props(dash_dcc):
 
     dash_dcc.wait_for_text_to_equal("#checkbox h4", "h4")
     dash_dcc.wait_for_text_to_equal("#radiobutton h6", "h6")
-    dash_dcc.wait_for_text_to_equal(#switch h5", "h5")
+    dash_dcc.wait_for_text_to_equal("#switch+label", "h5")

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -1,5 +1,5 @@
 from dash import Dash, dcc, html
-from dash_bootstrap_components import Checklist, Checkbox, RadioButton, RadioItems, Switch
+import dash_bootstrap_components as dbc
 
 
 def test_mdcap001_components_as_props(dash_dcc):

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -1,0 +1,40 @@
+from dash import Dash, dcc, html
+from dash_bootstrap_components import Checklist, Checkbox, RadioButton, RadioItems, Switch
+
+
+def test_mdcap001_components_as_props(dash_dcc):
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            dbc.Checklist(
+                [
+                    {"label": html.H2("H2 label"), "value": "h2"},
+                    {"label": html.A("Link in checklist", href="#"), "value": "a"},
+                ],
+                id="checklist",
+            ),
+            dbc.RadioItems(
+                [
+                    {"label": html.H3("on"), "value": "on"},
+                    {"label": html.P("off"), "value": "off"},
+                ],
+                id="radio-items",
+            ),
+            dbc.Checkbox(label= html.H4("h4"), value= "h4", id="checkbox"),
+            dbc.RadioButton(label=html.H6("h6"), value="h6", id="radiobutton),
+            dbc.Switch(label=html.H5("h5"), value="h5", id="switch)
+        ]
+    )
+
+    dash_dcc.start_server(app)
+
+    dash_dcc.wait_for_text_to_equal("#checklist h2", "H2 label")
+    dash_dcc.wait_for_text_to_equal("#checklist a", "Link in checklist")
+
+    dash_dcc.wait_for_text_to_equal("#radio-items h3", "on")
+    dash_dcc.wait_for_text_to_equal("#radio-items p", "off")
+
+    dash_dcc.wait_for_text_to_equal("#checkbox h4", "h4")
+    dash_dcc.wait_for_text_to_equal("#radiobutton h6", "h6")
+    dash_dcc.wait_for_text_to_equal(#switch h5", "h5")

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -36,5 +36,5 @@ def test_mdcap001_components_as_props(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#radio-items p", "off")
 
     dash_dcc.wait_for_text_to_equal("#checkbox+label", "h4")
-    dash_dcc.wait_for_text_to_equal("#radiobutton h6", "h6")
+    dash_dcc.wait_for_text_to_equal("#radiobutton+label", "h6")
     dash_dcc.wait_for_text_to_equal("#switch+label", "h5")

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -22,7 +22,7 @@ def test_mdcap001_components_as_props(dash_dcc):
                 id="radio-items",
             ),
             dbc.Checkbox(label= html.H4("h4"), value= "h4", id="checkbox"),
-            dbc.RadioButton(label=html.H6("h6"), value="h6", id="radiobutton),
+            dbc.RadioButton(label=html.H6("h6"), value="h6", id="radiobutton"),
             dbc.Switch(label=html.H5("h5"), value="h5", id="switch")
         ]
     )

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -35,6 +35,6 @@ def test_mdcap001_components_as_props(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#radio-items h3", "on")
     dash_dcc.wait_for_text_to_equal("#radio-items p", "off")
 
-    dash_dcc.wait_for_text_to_equal("#checkbox h4", "h4")
+    dash_dcc.wait_for_text_to_equal("#checkbox+label", "h4")
     dash_dcc.wait_for_text_to_equal("#radiobutton h6", "h6")
     dash_dcc.wait_for_text_to_equal("#switch+label", "h5")

--- a/tests/test_components_as_props
+++ b/tests/test_components_as_props
@@ -23,7 +23,7 @@ def test_mdcap001_components_as_props(dash_dcc):
             ),
             dbc.Checkbox(label= html.H4("h4"), value= "h4", id="checkbox"),
             dbc.RadioButton(label=html.H6("h6"), value="h6", id="radiobutton),
-            dbc.Switch(label=html.H5("h5"), value="h5", id="switch)
+            dbc.Switch(label=html.H5("h5"), value="h5", id="switch")
         ]
     )
 

--- a/tests/test_components_as_props.py
+++ b/tests/test_components_as_props.py
@@ -1,8 +1,8 @@
-from dash import Dash, dcc, html
+from dash import Dash,  html
 import dash_bootstrap_components as dbc
 
 
-def test_mdcap001_components_as_props(dash_dcc):
+def test_mdcap001_components_as_props(dash_duo):
     app = Dash(__name__)
 
     app.layout = html.Div(
@@ -27,14 +27,14 @@ def test_mdcap001_components_as_props(dash_dcc):
         ]
     )
 
-    dash_dcc.start_server(app)
+    dash_duo.start_server(app)
 
-    dash_dcc.wait_for_text_to_equal("#checklist h2", "H2 label")
-    dash_dcc.wait_for_text_to_equal("#checklist a", "Link in checklist")
+    dash_duo.wait_for_text_to_equal("#checklist h2", "H2 label")
+    dash_duo.wait_for_text_to_equal("#checklist a", "Link in checklist")
 
-    dash_dcc.wait_for_text_to_equal("#radio-items h3", "on")
-    dash_dcc.wait_for_text_to_equal("#radio-items p", "off")
+    dash_duo.wait_for_text_to_equal("#radio-items h3", "on")
+    dash_duo.wait_for_text_to_equal("#radio-items p", "off")
 
-    dash_dcc.wait_for_text_to_equal("#checkbox+label", "h4")
-    dash_dcc.wait_for_text_to_equal("#radiobutton+label", "h6")
-    dash_dcc.wait_for_text_to_equal("#switch+label", "h5")
+    dash_duo.wait_for_text_to_equal("#checkbox+label", "h4")
+    dash_duo.wait_for_text_to_equal("#radiobutton+label", "h6")
+    dash_duo.wait_for_text_to_equal("#switch+label", "h5")

--- a/tests/test_components_as_props.py
+++ b/tests/test_components_as_props.py
@@ -1,5 +1,5 @@
-from dash import Dash,  html
 import dash_bootstrap_components as dbc
+from dash import Dash, html
 
 
 def test_mdcap001_components_as_props(dash_duo):
@@ -10,7 +10,10 @@ def test_mdcap001_components_as_props(dash_duo):
             dbc.Checklist(
                 [
                     {"label": html.H2("H2 label"), "value": "h2"},
-                    {"label": html.A("Link in checklist", href="#"), "value": "a"},
+                    {
+                        "label": html.A("Link in checklist", href="#"),
+                        "value": "a",
+                    },
                 ],
                 id="checklist",
             ),
@@ -21,9 +24,9 @@ def test_mdcap001_components_as_props(dash_duo):
                 ],
                 id="radio-items",
             ),
-            dbc.Checkbox(label= html.H4("h4"), value= "h4", id="checkbox"),
+            dbc.Checkbox(label=html.H4("h4"), value="h4", id="checkbox"),
             dbc.RadioButton(label=html.H6("h6"), value="h6", id="radiobutton"),
-            dbc.Switch(label=html.H5("h5"), value="h5", id="switch")
+            dbc.Switch(label=html.H5("h5"), value="h5", id="switch"),
         ]
     )
 

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -1,9 +1,8 @@
-from dash import Dash
+from dash import Dash, dcc, html
 from dash.dependencies import Input, Output
 from dash_bootstrap_components import NavLink
-from dash import dcc, html
-from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 def test_dbnl001_auto_active(dash_duo):

--- a/tests/test_popover.py
+++ b/tests/test_popover.py
@@ -1,3 +1,4 @@
+import dash.testing.wait as wait
 from dash import Dash, html
 from dash_bootstrap_components import (
     Popover,
@@ -5,7 +6,6 @@ from dash_bootstrap_components import (
     PopoverHeader,
     themes,
 )
-import dash.testing.wait as wait
 from selenium.webdriver.common.action_chains import ActionChains
 
 


### PR DESCRIPTION
Added support for components in props for `Checklist, Checkbox, RadioButton, RadioItems`, and `Switch`