### PR TITLE
[Docs] Rename duplicate ids in docs

### DIFF
--- a/docs/components_page/components/input/components_in_labels.py
+++ b/docs/components_page/components/input/components_in_labels.py
@@ -15,13 +15,13 @@ radioitems = html.Div(
                 {"label": hotel, "value": 3},
             ],
             value=1,
-            id="radioitems-input",
+            id="radioitems-with-icons",
         ),
     ]
 )
 
 checkbox = dbc.Checkbox(
-    id="standalone-checkbox",
+    id="checkbox-with-link",
     label=html.Div(
         ["I agree to the ", html.A("Terms and Conditions", href="#")]
     ),


### PR DESCRIPTION
Causes a server error on first page load when the layout is validated.