### PR TITLE
Fix Alert navigation bug

### DIFF
--- a/src/components/alert/Alert.js
+++ b/src/components/alert/Alert.js
@@ -37,6 +37,7 @@ const Alert = props => {
         timeout.current = null;
       }
     }
+    return () => clearTimeout(timeout.current);
   }, [is_open]);
 
   const dismiss = () => {


### PR DESCRIPTION
Resolves error in multi-page apps due to `Alert` not cleaning up outstanding timers when unmounted.

cf. #920 and #960 