### PR TITLE
Prerelease 1.4.2-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.2-dev"
+__version__ = "1.4.2-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.4.2-dev",
+  "version": "1.4.2-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.4.2-dev"
+    assert __version__ == "1.4.2-rc1"


### PR DESCRIPTION
This is a patch release candidate of dash-bootstrap-components. This version contains updates and bug fixes but no new features. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Fixed

- Fixed navigation bug when using auto-dismissing `Alert` ([PR 962](https://github.com/facultyai/dash-bootstrap-components/pull/962))

### Changed
- Updated CDN links for Bootstrap and Bootswatch stylesheets ([PR 963](https://github.com/facultyai/dash-bootstrap-components/pull/963))