### PR TITLE
Sanitize href props with xss vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "ramda": "^0.27.1",
     "react": "^16.14.0",
     "react-bootstrap": "^2.2.2",
-    "react-dom": "^16.14.0"
+    "react-dom": "^16.14.0",
+    "@braintree/sanitize-url": "^7.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBBadge from 'react-bootstrap/Badge';
 import Link from '../../private/Link';
 import {bootstrapColors} from '../../private/BootstrapColors';
@@ -22,6 +23,11 @@ const Badge = props => {
     ...otherProps
   } = props;
 
+
+const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
+
   const incrementClicks = () => {
     if (setProps) {
       setProps({
@@ -34,10 +40,18 @@ const Badge = props => {
 
   otherProps[href ? 'preOnClick' : 'onClick'] = incrementClicks;
 
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
   return (
     <RBBadge
       as={href && Link}
-      href={href}
+      href={sanitizedUrl}
       bg={isBootstrapColor ? color : null}
       text={text_color}
       className={class_name || className}

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBBreadcrumb from 'react-bootstrap/Breadcrumb';
 
 import Link from '../../private/Link';
@@ -7,6 +8,36 @@ import Link from '../../private/Link';
 /**
  * Use breadcrumbs to create a navigation breadcrumb in your app.
  */
+
+const BreadcrumbItem = ({ item, idx, item_class_name, itemClassName, setProps }) => {
+
+  const sanitizedUrl = useMemo(() => {
+      return item.href ? sanitizeUrl(item.href) : undefined;
+  }, [item.href]);
+
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== item.href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${item.href}`),
+          });
+      }
+  }, [item.href, sanitizedUrl]);
+
+  return (
+    <RBBreadcrumb.Item
+      key={`${item.value}${idx}`}
+      active={item.active}
+      linkAs={sanitizedUrl && Link}
+      className={item_class_name || itemClassName}
+      href={sanitizedUrl}
+      linkProps={sanitizedUrl && {external_link: item.external_link}}
+    >
+      {item.label}
+    </RBBreadcrumb.Item>
+  );
+};
+
+
 const Breadcrumb = ({
   items,
   tag,
@@ -16,6 +47,7 @@ const Breadcrumb = ({
   item_class_name,
   itemClassName,
   item_style,
+  setProps,
   ...otherProps
 }) => (
   <RBBreadcrumb
@@ -27,16 +59,14 @@ const Breadcrumb = ({
     {...otherProps}
   >
     {(items || []).map((item, idx) => (
-      <RBBreadcrumb.Item
+      <BreadcrumbItem
         key={`${item.value}${idx}`}
-        active={item.active}
-        linkAs={item.href && Link}
-        className={item_class_name || itemClassName}
-        href={item.href}
-        linkProps={item.href && {external_link: item.external_link}}
-      >
-        {item.label}
-      </RBBreadcrumb.Item>
+        idx={idx}
+        item={item}
+        item_class_name={item_class_name}
+        itemClassName={itemClassName}
+        setProps={setProps}
+      />
     ))}
   </RBBreadcrumb>
 );

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBButton from 'react-bootstrap/Button';
 import Link from '../../private/Link';
 
@@ -34,6 +35,12 @@ const Button = props => {
     ...otherProps
   } = props;
 
+
+  const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+  }, [href]);
+
+
   const incrementClicks = () => {
     if (!disabled && setProps) {
       setProps({
@@ -42,7 +49,7 @@ const Button = props => {
       });
     }
   };
-  const useLink = href && !disabled;
+  const useLink = sanitizedUrl && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = onClick || incrementClicks;
 
   if (useLink) {
@@ -51,12 +58,21 @@ const Button = props => {
     otherProps['linkTarget'] = target;
   }
 
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
+
   return (
     <RBButton
       as={useLink ? Link : 'button'}
       variant={outline ? `outline-${color}` : color}
       type={useLink ? undefined : type}
-      href={disabled ? undefined : href}
+      href={disabled ? undefined : sanitizedUrl}
       disabled={disabled}
       download={useLink ? download : undefined}
       name={useLink ? undefined : name}

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBCard from 'react-bootstrap/Card';
 import Link from '../../private/Link';
 
@@ -15,8 +16,15 @@ const CardLink = props => {
     disabled,
     className,
     class_name,
+    href,
+    setProps,
     ...otherProps
   } = props;
+
+
+  const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
 
   const incrementClicks = () => {
     if (!disabled && props.setProps) {
@@ -27,6 +35,14 @@ const CardLink = props => {
     }
   };
 
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
   return (
     <RBCard.Link
       data-dash-is-loading={
@@ -35,6 +51,7 @@ const CardLink = props => {
       as={Link}
       preOnClick={incrementClicks}
       disabled={disabled}
+      href={sanitizedUrl}
       className={class_name || className}
       {...omit(['setProps', 'n_clicks', 'n_clicks_timestamp'], otherProps)}
     >

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -1,6 +1,7 @@
-import React, {useContext} from 'react';
+import React, {useContext, useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBDropdown from 'react-bootstrap/Dropdown';
 
 import Link from '../../private/Link';
@@ -26,6 +27,18 @@ const DropdownMenuItem = props => {
     ...otherProps
   } = props;
 
+  const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
+
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
   const context = useContext(DropdownMenuContext);
 
   const handleClick = e => {
@@ -40,7 +53,7 @@ const DropdownMenuItem = props => {
     }
   };
 
-  const useLink = href && !disabled;
+  const useLink = sanitizedUrl && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = e => handleClick(e);
 
   if (header) {
@@ -52,7 +65,7 @@ const DropdownMenuItem = props => {
   return (
     <RBDropdown.Item
       as={useLink ? Link : 'button'}
-      href={useLink ? href : undefined}
+      href={useLink ? sanitizedUrl : undefined}
       disabled={disabled}
       target={useLink ? target : undefined}
       className={class_name || className}

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBListGroupItem from 'react-bootstrap/ListGroupItem';
 import Link from '../../private/Link';
 import {bootstrapColors} from '../../private/BootstrapColors';
@@ -24,6 +25,18 @@ const ListGroupItem = props => {
     ...otherProps
   } = props;
 
+  const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
+
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
   const incrementClicks = () => {
     if (!disabled && setProps) {
       setProps({
@@ -33,13 +46,13 @@ const ListGroupItem = props => {
     }
   };
   const isBootstrapColor = bootstrapColors.has(color);
-  const useLink = href && !disabled;
+  const useLink = sanitizedUrl && !disabled;
   otherProps[useLink ? 'preOnClick' : 'onClick'] = incrementClicks;
 
   return (
     <RBListGroupItem
       as={useLink ? Link : 'li'}
-      href={href}
+      href={sanitizedUrl}
       target={useLink ? target : undefined}
       disabled={disabled}
       variant={isBootstrapColor ? color : null}

--- a/src/components/nav/NavbarBrand.js
+++ b/src/components/nav/NavbarBrand.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useEffect, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import RBNavbarBrand from 'react-bootstrap/NavbarBrand';
 import Link from '../../private/Link';
 
@@ -8,12 +9,26 @@ import Link from '../../private/Link';
  * Call out attention to a brand name or site title within a navbar.
  */
 const NavbarBrand = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, loading_state, className, class_name, href, setProps, ...otherProps} = props;
+
+  const sanitizedUrl = useMemo(() => {
+      return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
+
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${href}`),
+          });
+      }
+  }, [href, sanitizedUrl]);
+
   return (
     <RBNavbarBrand
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      as={props.href ? Link : 'span'}
+      as={sanitizedUrl ? Link : 'span'}
+      href={sanitizedUrl}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }

--- a/src/components/nav/NavbarSimple.js
+++ b/src/components/nav/NavbarSimple.js
@@ -1,9 +1,10 @@
-import React, {useState} from 'react';
+import React, {useState, useMemo, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNavbar from 'react-bootstrap/Navbar';
 import RBContainer from 'react-bootstrap/Container';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 
 import Nav from './Nav';
 import NavbarBrand from './NavbarBrand';
@@ -29,13 +30,28 @@ const NavbarSimple = props => {
     loading_state,
     className,
     class_name,
+    setProps,
     ...otherProps
   } = props;
+
+  const sanitizedUrl = useMemo(() => {
+      return brand_href ? sanitizeUrl(brand_href) : undefined;
+    }, [brand_href]);
+
+
   const isBootstrapColor = bootstrapColors.has(color);
 
   const [navbarOpen, setNavbarOpen] = useState(false);
 
   const toggle = () => setNavbarOpen(!navbarOpen);
+
+  useEffect(() => {
+      if (sanitizedUrl && sanitizedUrl !== brand_href) {
+          setProps({
+              _dash_error: new Error(`Dangerous link detected:: ${brand_href}`),
+          });
+      }
+  }, [brand_href, sanitizedUrl]);
 
   return (
     <RBNavbar
@@ -52,7 +68,7 @@ const NavbarSimple = props => {
       <RBContainer fluid={fluid}>
         {brand && (
           <NavbarBrand
-            href={brand_href}
+            href={sanitizedUrl}
             style={brand_style}
             external_link={brand_external_link}
           >

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export {default as CardHeader} from './components/card/CardHeader';
 export {default as CardImg} from './components/card/CardImg';
 export {default as CardImgOverlay} from './components/card/CardImgOverlay';
 export {default as CardLink} from './components/card/CardLink';
-export {default as Carousel} from './components/carousel/Carousel';
+export {default as Carousel} from './components/carousel/Carousel';``
 export {default as Checkbox} from './components/input/Checkbox';
 export {default as Checklist} from './components/input/Checklist';
 export {default as Col} from './components/layout/Col';

--- a/usage.py
+++ b/usage.py
@@ -1,0 +1,70 @@
+from dash import Dash, html
+import dash_bootstrap_components as dbc
+
+app = Dash(__name__)
+
+NavLink1 = dbc.NavLink("dbc link1")
+NavLink2 = dbc.NavLink("dbc link2", href="javascript:alert('NavLink')")
+
+NavbarSimple = dbc.NavbarSimple(
+    brand="NavbarSimple",
+    brand_href="javascript:alert('NavbarSimple')",
+)
+Badge = dbc.Badge("badge", href="javascript:alert('Badge')")
+
+
+Breadcrumb = dbc.Breadcrumb(
+    items=[
+        {
+            "label": "Docs",
+            "href": "javascript:alert('Breadcrumb1')",
+            "external_link": True,
+        },
+        {
+            "label": "Components",
+            "href": "javascript:alert('Breadcrumb2')",
+            "external_link": True,
+        },
+        {"label": "Breadcrumb", "active": True},
+    ],
+)
+
+Button = dbc.Button("button", href="javascript:alert('Button')")
+
+CardLink = dbc.Card(dbc.CardLink("cardlink", href="javascript:alert('Card')"))
+
+ListGroupItem = dbc.ListGroup(
+    [
+        dbc.ListGroupItem("Active item", active=True),
+        dbc.ListGroupItem("Item 2", href="javascript:alert('ListGroupItem')"),
+    ]
+)
+
+NavbarBrand = dbc.Navbar(
+    dbc.NavbarBrand("Navbar Brand", href="javascript:alert('NavbarBrand')")
+)
+
+DropdownMenuItem = dbc.DropdownMenu(
+    dbc.DropdownMenuItem(
+        "DropdownMenuItem", href="javascript:alert('DropdownMenuItem')"
+    )
+)
+
+
+app.layout = html.Div(
+    [
+        NavLink1,
+        NavLink2,
+        NavbarSimple,
+        Badge,
+        Breadcrumb,
+        Button,
+        CardLink,
+        ListGroupItem,
+        NavbarBrand,
+        DropdownMenuItem,
+    ]
+)
+
+if __name__ == "__main__":
+    app.run_server(debug=True)


### PR DESCRIPTION
Sanitize html props that are vulnerable to xss vulnerability if user data is inserted.

Here's an example:

```

from dash import Dash, html
import dash_bootstrap_components as dbc

app=Dash(__name__)

app.layout = html.Div(
    dbc.NavLink("link",  href='javascript:alert(1)')
)

if __name__ == '__main__':
    app.run_server(debug=True)

```


Applied the same fix as  https://github.com/plotly/dash/pull/2732

The `href` prop is sanitized using the [braintree/sanitize-url](https://www.npmjs.com/package/@braintree/sanitize-url)

Content  with  vulnerabilities are replaced with "about:blank", and an error message is sent.

Dash 2.15 has a new prop:
> Add special key `_dash_error` to `setProps`, allowing component developers to send error without throwing in render. Usage `props.setProps({_dash_error: new Error("custom error")})`

I've included this, but it only sends the error message when using Dash 2.15.  Earlier Dash versions will not show an error in the console or the dev tools, but the prop is still sanitized.  

Would you like to bump the  `install_requires` to `dash>=2.15`  ?  I'm not sure how that would affect people that need to specify a dash version to get certain flask version. 

Before writing the tests would you like to take a quick look?  You can run `usage.py` to see all the components that are updated so far.

To Do:
- [ ] Carousel  
- [ ] Tests
- [ ] Missing any other components?
