### PR TITLE
Prerelease 1.6.0-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.0-dev"
+__version__ = "1.6.0-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.6.0-dev",
+  "version": "1.6.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.6.0-dev"
+    assert __version__ == "1.6.0-rc1"


### PR DESCRIPTION
This is a release candidate of dash-bootstrap-components v1.6.0. This version makes some improvements to `Accordion`, `Modal` and `Progress` as well as updating CDN links. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Added
- The `title` property of `AccordionItem` can now be an arbitrary Dash component ([PR 988](https://github.com/facultyai/dash-bootstrap-components/pull/988))
- You can now set `enforceFocus=False` on a `Modal` to allow components in the background to receive focus while the `Modal` is open ([PR 1001](https://github.com/facultyai/dash-bootstrap-components/pull/1001))
- The documentation now has a dark mode ([PR 984](https://github.com/facultyai/dash-bootstrap-components/pull/984))

### Fixed
- The `min` and `max` properties of a `Progress` bar are propagated to its children ([PR 986](https://github.com/facultyai/dash-bootstrap-components/pull/986))
- Fixed console errors originating from `Tooltip` component ([PR 1008](https://github.com/facultyai/dash-bootstrap-components/pull/1008))
- Fix error caused by `Tooltip` closing as component unmounts ([PR 1008](https://github.com/facultyai/dash-bootstrap-components/pull/1008))

### Changed
- Drop support for Python 3.7 as it is EOL ([PR 995](https://github.com/facultyai/dash-bootstrap-components/pull/995))
- `href` props are sanitized in the same was as in first party Dash components ([PR 1000](https://github.com/facultyai/dash-bootstrap-components/pull/1000))
- The `themes` module now links to Bootstrap 5.3.3 ([PR 1013](https://github.com/facultyai/dash-bootstrap-components/pull/1013))

Thanks @arthur-FD, @arunsathiya and @AnnMarieW for contributing to this release!