### PR TITLE
Fix docs mobile burger menu style in dark mode

### DIFF
--- a/docs/static/docs.css
+++ b/docs/static/docs.css
@@ -209,12 +209,12 @@ span.hljs-meta {
 }
 
 .dbcd-nav-toggle {
-  color: rgb(33, 37, 41);
+  color: var(--bs-secondary-color);
   padding: 0.25rem 0.75rem;
 }
 
 .dbcd-nav-toggle:hover {
-  color: rgb(30, 30, 35);
+  color: var(--bs-body-color);
 }
 
 .dbcd-nav-link {


### PR DESCRIPTION
closes #1025

Not sure if you want to do something more elaborate, but this will make it visible in dark an light modes

![dbc-burger](https://github.com/facultyai/dash-bootstrap-components/assets/72614349/f95077d5-74c7-4244-bec4-e12c69b8d392)
