### PR TITLE
Update spinner.md url

### DIFF
--- a/docs/components_page/components/spinner.md
+++ b/docs/components_page/components/spinner.md
@@ -5,7 +5,7 @@ lead: Indicate the loading state of a component or page with the `Spinner` compo
 
 ## Examples
 
-The `Spinner` component can be used either to create a standalone spinner, or used in the same way as [dcc.Loading](https://dash.plot.ly/dash-core-components/loading) by passing children.
+The `Spinner` component can be used either to create a standalone spinner, or used in the same way as [dcc.Loading](https://dash.plotly.com/dash-core-components/loading) by passing children.
 
 To create a simple spinner, just add `dbc.Spinner()` to your layout. By default, `Spinner` uses the current text color for its border color. Override the color of the `Spinner` using the `color` argument and one of the eight supported contextual color names.
 


### PR DESCRIPTION
The url for `dcc.Loading` object linked in the documentation redirects to the homepage: [https://dash.plotly.com/](https://dash.plotly.com). This MR points it to go the current [dcc.Loading](https://dash.plotly.com/dash-core-components/loading) page.