### PR TITLE
Update deprecated download / upload artifact action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Set up Python 3.12
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -101,7 +101,7 @@ jobs:
         run: npm ci
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Set up Python 3.12
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install Dash
@@ -63,12 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.12
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != '3.12'
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     services:
       hub:
         image: selenium/hub:3.141.59-gold

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build dash-bootstrap-components
         run: npm run build
       - name: Upload generated files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dash-bootstrap-components
           path: dash_bootstrap_components/_components
@@ -76,7 +76,7 @@ jobs:
       - name: Lint Python source
         if: matrix.python-version == '3.12'
         run: nox -s lint
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dash-bootstrap-components
           path: dash_bootstrap_components/_components

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def format_(session):
     session.run("isort", *SOURCES)
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session):
     session.install("pytest")
     session.install("dash[testing]>=2.0.0")

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ setup(
     classifiers=[
         "Framework :: Dash",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     extras_require={"pandas": ["numpy", "pandas"]},
-    python_requires=">=3.8, <4",
+    python_requires=">=3.9, <4",
 )


### PR DESCRIPTION
The version we were using was [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
