### PR TITLE
Include 'time' Input Type

### DIFF
--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -215,7 +215,7 @@ Input.propTypes = {
    * The type of control to render
    */
   type: PropTypes.oneOf([
-    // Only allowing the input types with wide browser compatability
+    // Only allowing the input types with wide browser compatibility
     'text',
     'number',
     'password',
@@ -224,7 +224,8 @@ Input.propTypes = {
     'search',
     'tel',
     'url',
-    'hidden'
+    'hidden',
+    'time'
   ]),
 
   /**


### PR DESCRIPTION
The 'time' input to `<input>` use to not be supported by Safari, which is likely why it wasn't included to begin with ([related Dash thread](https://github.com/plotly/dash-core-components/issues/642)). However, as of Safari 14.1, it now has [full support across all modern browers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time).

I simply added it as a option to `Input.propTypes.type`, but I see there are other areas where it could potentially be added (e.g. `Input.propTypes.inputmode/inputMode`).

Using `dbc.Input(type="time")` already works as expected, so I figured this just requires an update of the docs.