### PR TITLE
Prerelease 1.7.0-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.1-dev"
+__version__ = "1.7.0-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.6.1-dev",
+  "version": "1.7.0-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.6.1-dev"
+    assert __version__ == "1.7.0-rc1"


### PR DESCRIPTION
This is a release candidate of dash-bootstrap-components v1.7.0. This version exposes some new props for `Modal`, and `Textarea` to allow users to customise the behaviour of those components, and extends the functionality of the `debounce` prop in `Input` and `Textarea` components. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Added
- Added `content_style` / `contentStyle` and `dialog_style` / `dialogStyle` props to `Modal` to complement the existing `contentClassName` and `dialogClassName` props ([PR 1029](https://github.com/facultyai/dash-bootstrap-components/pull/1029))
- Added `submit_on_enter` prop to `Textarea` to allow users to disable default behaviour of incrementing `n_submit` when the Enter key is pressed ([PR 1036](https://github.com/facultyai/dash-bootstrap-components/pull/1036))
- Allow numeric debounce in `Input` and `Textarea` components ([PR 1056](https://github.com/facultyai/dash-bootstrap-components/pull/1056))