### PR TITLE
Loading component changes

### DIFF
--- a/src/components/accordion/Accordion.js
+++ b/src/components/accordion/Accordion.js
@@ -5,6 +5,7 @@ import RBAccordion from 'react-bootstrap/Accordion';
 
 import {parseChildrenToArray, resolveChildProps} from '../../private/util';
 import {AccordionContext} from '../../private/AccordionContext';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A self contained Accordion component. Build up the children using the
@@ -14,7 +15,6 @@ const Accordion = props => {
   let {
     children,
     active_item,
-    loading_state,
     key,
     setProps,
     class_name,
@@ -70,9 +70,7 @@ const Accordion = props => {
   return (
     <RBAccordion
       key={key}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       activeKey={active_item}
       defaultActiveKey={start_collapsed ? null : active_item}
       alwaysOpen={always_open}
@@ -156,24 +154,6 @@ Accordion.propTypes = {
    * Set to True for all items to be collapsed initially.
    */
   start_collapsed: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/accordion/AccordionItem.js
+++ b/src/components/accordion/AccordionItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBAccordion from 'react-bootstrap/Accordion';
 
-import {stringifyId} from '../../private/util';
+import {getLoadingState, stringifyId} from '../../private/util';
 import {AccordionContext} from '../../private/AccordionContext';
 
 /**
@@ -12,7 +12,6 @@ import {AccordionContext} from '../../private/AccordionContext';
 const AccordionItem = ({
   title,
   item_id,
-  loading_state,
   class_name,
   className,
   id,
@@ -31,9 +30,7 @@ const AccordionItem = ({
         ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       <RBAccordion.Header onClick={() => toggle(itemID)}>
         {title}
@@ -84,25 +81,7 @@ AccordionItem.propTypes = {
    * will be set to "item-i" where i is (zero indexed) position of item in list
    * items pased to Accordion component.
    */
-  item_id: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  item_id: PropTypes.string
 };
 
 export default AccordionItem;

--- a/src/components/alert/Alert.js
+++ b/src/components/alert/Alert.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBAlert from 'react-bootstrap/Alert';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Alert allows you to create contextual feedback messages on user actions.
@@ -13,7 +14,6 @@ import {bootstrapColors} from '../../private/BootstrapColors';
 const Alert = ({
   children,
   dismissable,
-  loading_state,
   setProps,
   style,
   class_name,
@@ -58,9 +58,7 @@ const Alert = ({
         ['persistence', 'persisted_props', 'persistence_type', 'setProps'],
         otherProps
       )}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBAlert>
@@ -137,24 +135,6 @@ Alert.propTypes = {
    * Duration in milliseconds after which the Alert dismisses itself.
    */
   duration: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -4,6 +4,7 @@ import {omit} from 'ramda';
 import RBBadge from 'react-bootstrap/Badge';
 import Link from '../../private/Link';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Badges can be used to add counts or labels to other components.
@@ -12,7 +13,6 @@ const Badge = props => {
   const {
     children,
     href,
-    loading_state,
     setProps,
     style,
     className,
@@ -41,9 +41,7 @@ const Badge = props => {
       className={class_name || className}
       style={!isBootstrapColor ? {backgroundColor: color, ...style} : style}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBBadge>
@@ -117,24 +115,6 @@ Badge.propTypes = {
    * HTML tag to use for the Badge. Default: span.
    */
   tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * If true, the browser will treat this as an external link,

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import RBBreadcrumb from 'react-bootstrap/Breadcrumb';
 
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use breadcrumbs to create a navigation breadcrumb in your app.
@@ -10,7 +11,6 @@ import Link from '../../private/Link';
 const Breadcrumb = ({
   items,
   tag,
-  loading_state,
   class_name,
   className,
   item_class_name,
@@ -20,9 +20,7 @@ const Breadcrumb = ({
 }) => (
   <RBBreadcrumb
     as={tag}
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
     className={class_name || className}
     {...otherProps}
   >
@@ -130,25 +128,7 @@ Breadcrumb.propTypes = {
   /**
    * HTML tag to use for the outer breadcrumb component. Default: "nav".
    */
-  tag: PropTypes.object,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.object
 };
 
 export default Breadcrumb;

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RBButton from 'react-bootstrap/Button';
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for creating Bootstrap buttons with different style options. The
@@ -15,7 +16,6 @@ const Button = ({
   children,
   disabled,
   href,
-  loading_state,
   setProps,
   target,
   type,
@@ -58,9 +58,7 @@ const Button = ({
       className={class_name || className}
       rel={useLink ? rel : undefined}
       {...otherProps}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBButton>
@@ -156,24 +154,6 @@ Button.propTypes = {
    * lightweight style.
    */
   outline: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Target attribute to pass on to link if using Button as an external link.

--- a/src/components/buttongroup/ButtonGroup.js
+++ b/src/components/buttongroup/ButtonGroup.js
@@ -2,20 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBButtonGroup from 'react-bootstrap/ButtonGroup';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for creating groups of buttons. Can be used with `Button` or
  * `DropdownMenu`.
  */
 const ButtonGroup = props => {
-  const {children, loading_state, class_name, className, ...otherProps} = props;
+  const {children, class_name, className, ...otherProps} = props;
   return (
     <RBButtonGroup
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBButtonGroup>
@@ -67,25 +66,7 @@ ButtonGroup.propTypes = {
   /**
    * Size of button group, options: 'sm', 'md', 'lg'.
    */
-  size: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  size: PropTypes.string
 };
 
 export default ButtonGroup;

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCard from 'react-bootstrap/Card';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Component for creating Bootstrap cards. Use in conjunction with CardBody,
@@ -17,7 +18,6 @@ const Card = props => {
     inverse,
     outline,
     style,
-    loading_state,
     className,
     class_name,
     ...otherProps
@@ -25,9 +25,7 @@ const Card = props => {
   const isBootstrapColor = bootstrapColors.has(color);
   return (
     <RBCard
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       text={inverse ? 'white' : null}
       bg={isBootstrapColor && !outline ? color : null}
       border={isBootstrapColor && outline ? color : null}
@@ -99,25 +97,7 @@ Card.propTypes = {
   /**
    * Invert text colours for use with a darker background.
    */
-  inverse: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  inverse: PropTypes.bool
 };
 
 export default Card;

--- a/src/components/card/CardBody.js
+++ b/src/components/card/CardBody.js
@@ -2,18 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCard from 'react-bootstrap/Card';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Wrap the content of your `Card` in `CardBody` to apply padding and other
  * styles.
  */
 const CardBody = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBCard.Body
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
     >
@@ -62,25 +61,7 @@ CardBody.propTypes = {
   /**
    * HTML tag to use for the card body, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default CardBody;

--- a/src/components/card/CardFooter.js
+++ b/src/components/card/CardFooter.js
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCard from 'react-bootstrap/Card';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use the CardFooter component to add a footer to any card.
  */
 const CardFooter = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBCard.Footer
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
     >
@@ -61,25 +60,7 @@ CardFooter.propTypes = {
   /**
    * HTML tag to use for the card footer, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default CardFooter;

--- a/src/components/card/CardGroup.js
+++ b/src/components/card/CardGroup.js
@@ -2,18 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCardGroup from 'react-bootstrap/CardGroup';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use CardGroup to render cards as a single, attached element of columns with
  * equal width and height.
  */
 const CardGroup = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBCardGroup
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
     >
@@ -62,25 +61,7 @@ CardGroup.propTypes = {
   /**
    * HTML tag to use for the card group, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default CardGroup;

--- a/src/components/card/CardHeader.js
+++ b/src/components/card/CardHeader.js
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCardHeader from 'react-bootstrap/CardHeader';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use the CardHeader component to add a header to any card.
  */
 const CardHeader = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBCardHeader
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
     >
@@ -61,25 +60,7 @@ CardHeader.propTypes = {
   /**
    * HTML tag to use for the card header, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default CardHeader;

--- a/src/components/card/CardImg.js
+++ b/src/components/card/CardImg.js
@@ -2,25 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCardImg from 'react-bootstrap/CardImg';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use CardImg to add images to your cards.
  */
 const CardImg = props => {
-  const {
-    children,
-    loading_state,
-    className,
-    class_name,
-    top,
-    bottom,
-    ...otherProps
-  } = props;
+  const {children, className, class_name, top, bottom, ...otherProps} = props;
   return (
     <RBCardImg
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       variant={top ? 'top' : bottom ? 'bottom' : null}
       {...omit(['setProps'], otherProps)}
@@ -98,25 +89,7 @@ CardImg.propTypes = {
   /**
    * Text to be displayed as a tooltip when hovering
    */
-  title: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  title: PropTypes.string
 };
 
 export default CardImg;

--- a/src/components/card/CardImgOverlay.js
+++ b/src/components/card/CardImgOverlay.js
@@ -2,18 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCard from 'react-bootstrap/Card';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use CardImgOverlay to turn an image into the background of your card and add
  * text on top of it.
  */
 const CardImgOverlay = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBCard.ImgOverlay
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
     >
@@ -62,25 +61,7 @@ CardImgOverlay.propTypes = {
   /**
    * HTML tag to use for the card image overlay, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default CardImgOverlay;

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RBCard from 'react-bootstrap/Card';
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use card link to add consistently styled links to your cards. Links can be
@@ -9,7 +10,6 @@ import Link from '../../private/Link';
  */
 const CardLink = ({
   children,
-  loading_state,
   disabled,
   className,
   class_name,
@@ -25,9 +25,7 @@ const CardLink = ({
 
   return (
     <RBCard.Link
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       as={Link}
       preOnClick={incrementClicks}
       disabled={disabled}
@@ -96,24 +94,6 @@ CardLink.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Target attribute to pass on to the link. Only applies to external links.

--- a/src/components/carousel/Carousel.js
+++ b/src/components/carousel/Carousel.js
@@ -5,6 +5,7 @@ import {omit} from 'ramda';
 import RBCarousel from 'react-bootstrap/Carousel';
 
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Component for creating Bootstrap carousel.  This component is a slideshow
@@ -15,7 +16,6 @@ const Carousel = ({
   style,
   class_name,
   className,
-  loading_state,
   setProps,
   interval,
   active_index = 0,
@@ -64,9 +64,7 @@ const Carousel = ({
   return (
     <div style={style} className={class_name || className}>
       <RBCarousel
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
+        data-dash-is-loading={getLoadingState() || undefined}
         activeIndex={active_index}
         onSelect={idx => setProps({active_index: idx})}
         interval={interval || null}
@@ -220,24 +218,6 @@ Carousel.propTypes = {
    * If set to None, carousel will not Autoplay (i.e. will not automatically cycle).
    */
   interval: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/collapse/Collapse.js
+++ b/src/components/collapse/Collapse.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCollapse from 'react-bootstrap/Collapse';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Hide or show content with a vertical collapsing animation. Visibility of the
@@ -14,7 +15,6 @@ const Collapse = React.forwardRef(
       children,
       is_open,
       navbar,
-      loading_state,
       className,
       class_name,
       tag,
@@ -30,9 +30,7 @@ const Collapse = React.forwardRef(
         className={class_name || className}
         dimension={dimension}
         {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
+        data-dash-is-loading={getLoadingState() || undefined}
       >
         <div ref={ref} className={navbar && 'navbar-collapse'}>
           {children}
@@ -88,24 +86,6 @@ Collapse.propTypes = {
    * Set to True when using a collapse inside a navbar.
    */
   navbar: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * The dimension used when collapsing e.g. height will collapse vertically,

--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -9,6 +9,7 @@ import Nav from 'react-bootstrap/Nav';
 import {DropdownMenuContext} from '../../private/DropdownMenuContext';
 import {bootstrapColors} from '../../private/BootstrapColors';
 import DropdownToggle from '../../private/DropdownToggle';
+import {getLoadingState} from '../../private/util';
 
 /**
  * DropdownMenu creates an overlay useful for grouping together links and other
@@ -24,7 +25,6 @@ const DropdownMenu = ({
   right,
   align_end,
   direction,
-  loading_state,
   color,
   group,
   toggle_style,
@@ -72,9 +72,7 @@ const DropdownMenu = ({
         }}
         align={align_end ? 'end' : right ? 'end' : 'start'}
         {...omit(['setProps'], otherProps)}
-        data-dash-is-loading={
-          (loading_state && loading_state.is_loading) || undefined
-        }
+        data-dash-is-loading={getLoadingState() || undefined}
       >
         <DropdownToggle
           caret={caret}
@@ -239,24 +237,6 @@ DropdownMenu.propTypes = {
    * and 'lg' to large.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Set group to True if the DropdownMenu is inside a ButtonGroup.

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -5,6 +5,7 @@ import RBDropdown from 'react-bootstrap/Dropdown';
 
 import Link from '../../private/Link';
 import {DropdownMenuContext} from '../../private/DropdownMenuContext';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use DropdownMenuItem to build up the content of a DropdownMenu.
@@ -12,7 +13,6 @@ import {DropdownMenuContext} from '../../private/DropdownMenuContext';
 const DropdownMenuItem = ({
   children,
   href,
-  loading_state,
   target,
   disabled,
   setProps,
@@ -52,9 +52,7 @@ const DropdownMenuItem = ({
       target={useLink ? target : undefined}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBDropdown.Item>
@@ -145,24 +143,6 @@ DropdownMenuItem.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Target attribute to pass on to the link. Only applies to external links.

--- a/src/components/fade/Fade.js
+++ b/src/components/fade/Fade.js
@@ -2,22 +2,15 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBFade from 'react-bootstrap/Fade';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Hide or show content with a fading animation. Visibility of the children is
  * controlled by the `is_open` prop which can be targetted by callbacks.
  */
 const Fade = React.forwardRef((props, ref) => {
-  const {
-    children,
-    is_in,
-    loading_state,
-    style,
-    className,
-    class_name,
-    tag,
-    ...otherProps
-  } = props;
+  const {children, is_in, style, className, class_name, tag, ...otherProps} =
+    props;
 
   // set visibility to hidden after transition has completed to hide tooltips
   const [hidden, setHidden] = useState(!is_in);
@@ -31,9 +24,7 @@ const Fade = React.forwardRef((props, ref) => {
       className={class_name || className}
       as={tag}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       <div ref={ref}>{children}</div>
     </RBFade>
@@ -113,25 +104,7 @@ Fade.propTypes = {
   /**
    * HTML tag to use for the fade component. Default: div.
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default Fade;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RBForm from 'react-bootstrap/Form';
+import {getLoadingState} from '../../private/util';
 
 /**
  * The Form component can be used to organise collections of input components
@@ -8,7 +9,6 @@ import RBForm from 'react-bootstrap/Form';
  */
 const Form = ({
   children,
-  loading_state,
   setProps,
   className,
   class_name,
@@ -28,9 +28,7 @@ const Form = ({
       }}
       className={class_name || className}
       {...otherProps}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBForm>
@@ -95,25 +93,7 @@ Form.propTypes = {
    * be posted to the endpoint specified by `action` on submit events, set
    * prevent_default_on_submit to False. Defaults to True.
    */
-  prevent_default_on_submit: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  prevent_default_on_submit: PropTypes.bool
 };
 
 export default Form;

--- a/src/components/form/FormFeedback.js
+++ b/src/components/form/FormFeedback.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBFormControl from 'react-bootstrap/FormControl';
+import {getLoadingState} from '../../private/util';
 
 /**
  * The FormFeedback component can be used to provide feedback on input values
@@ -9,14 +10,12 @@ import RBFormControl from 'react-bootstrap/FormControl';
  * `invalid` props of the associated input to toggle visibility.
  */
 const FormFeedback = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBFormControl.Feedback
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBFormControl.Feedback>
@@ -68,25 +67,7 @@ FormFeedback.propTypes = {
   /**
    * Use styled tooltips to display validation feedback.
    */
-  tooltip: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tooltip: PropTypes.bool
 };
 
 export default FormFeedback;

--- a/src/components/form/FormFloating.js
+++ b/src/components/form/FormFloating.js
@@ -2,28 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBFormFloating from 'react-bootstrap/FormFloating';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for adding float labels to form controls in forms.
  */
 const FormFloating = props => {
-  const {
-    children,
-    html_for,
-    className,
-    class_name,
-    loading_state,
-    ...otherProps
-  } = props;
+  const {children, html_for, className, class_name, ...otherProps} = props;
 
   return (
     <RBFormFloating
       htmlFor={html_for}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBFormFloating>
@@ -70,25 +62,7 @@ FormFloating.propTypes = {
   /**
    * Set the `for` attribute of the label to bind it to a particular element
    */
-  html_for: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  html_for: PropTypes.string
 };
 
 export default FormFloating;

--- a/src/components/form/FormText.js
+++ b/src/components/form/FormText.js
@@ -4,20 +4,13 @@ import classNames from 'classnames';
 import {omit} from 'ramda';
 import RBFormText from 'react-bootstrap/FormText';
 import {bootstrapTextColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Add explanatory text below your input components.
  */
 const FormText = props => {
-  const {
-    children,
-    loading_state,
-    color,
-    style,
-    className,
-    class_name,
-    ...otherProps
-  } = props;
+  const {children, color, style, className, class_name, ...otherProps} = props;
   const isBootstrapColor = bootstrapTextColors.has(color);
   const classes = classNames(
     class_name || className,
@@ -28,9 +21,7 @@ const FormText = props => {
       style={!isBootstrapColor ? {color: color, ...style} : style}
       className={classes}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBFormText>
@@ -79,25 +70,7 @@ FormText.propTypes = {
    * muted, light, dark, body, white, black-50, white-50 or any valid CSS color of
    * your choice (e.g. a hex code, a decimal code or a CSS color name).
    */
-  color: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  color: PropTypes.string
 };
 
 export default FormText;

--- a/src/components/form/Label.js
+++ b/src/components/form/Label.js
@@ -4,6 +4,7 @@ import {omit} from 'ramda';
 import RBFormLabel from 'react-bootstrap/FormLabel';
 import classNames from 'classnames';
 import {bootstrapTextColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 const alignMap = {
   start: 'align-self-start',
@@ -29,7 +30,6 @@ const Label = ({
   class_name,
   color,
   style,
-  loading_state,
   check,
   align = 'center',
   ...otherProps
@@ -66,9 +66,7 @@ const Label = ({
       className={classes}
       style={!isBootstrapColor ? {color: color, ...style} : style}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBFormLabel>
@@ -208,25 +206,7 @@ Label.propTypes = {
    * muted, light, dark, body, white, black-50, white-50 or any valid CSS color of
    * your choice (e.g. a hex code, a decimal code or a CSS color name).
    */
-  color: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  color: PropTypes.string
 };
 
 export default Label;

--- a/src/components/input/Checkbox.js
+++ b/src/components/input/Checkbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {append, includes, without} from 'ramda';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
@@ -17,7 +17,6 @@ const Checkbox = ({
   id,
   label,
   label_id,
-  loading_state,
   name,
   setProps,
   value = false,
@@ -34,9 +33,7 @@ const Checkbox = ({
   <div
     className={classNames('form-check', class_name || className)}
     style={style}
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
   >
     <input
       id={id}
@@ -168,24 +165,6 @@ Checkbox.propTypes = {
    * The value of the input.
    **/
   value: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/Checklist.js
+++ b/src/components/input/Checklist.js
@@ -4,6 +4,7 @@ import {append, includes, without} from 'ramda';
 import classNames from 'classnames';
 
 import {sanitizeOptions} from '../../private/util';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
@@ -18,7 +19,6 @@ const Checklist = ({
   id,
   style,
   key,
-  loading_state,
   name,
   inputCheckedClassName,
   input_checked_class_name,
@@ -118,9 +118,7 @@ const Checklist = ({
       style={style}
       className={class_name || className}
       key={key}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {items}
     </div>
@@ -368,24 +366,6 @@ Checklist.propTypes = {
    * Set to True to render toggle-like switches instead of checkboxes.
    */
   switch: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,8 +1,9 @@
-import React, {forwardRef, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {isNil, omit} from 'ramda';
 import isNumeric from 'fast-isnumeric';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 const convert = val => (isNumeric(val) ? +val : NaN);
 const isEquivalent = (v1, v2) => v1 === v2 || (isNaN(v1) && isNaN(v2));
@@ -26,7 +27,6 @@ const Input = ({
   size,
   html_size,
   setProps,
-  loading_state,
   className,
   class_name,
   autoComplete,
@@ -152,9 +152,7 @@ const Input = ({
       )}
       valid={valid ? 'true' : undefined}
       invalid={invalid ? 'true' : undefined}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       autoComplete={autocomplete || autoComplete}
       autoFocus={autofocus || autoFocus}
       inputMode={inputmode || inputMode}
@@ -587,24 +585,6 @@ Input.propTypes = {
    * of milliseconds.
    */
   debounce: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/InputGroup.js
+++ b/src/components/input/InputGroup.js
@@ -2,19 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBInputGroup from 'react-bootstrap/InputGroup';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for grouping together inputs and buttons, dropdowns or text.
  */
 const InputGroup = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBInputGroup
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBInputGroup>
@@ -62,25 +61,7 @@ InputGroup.propTypes = {
    * Set the size of the Input. Options: 'sm' (small), 'md' (medium)
    * or 'lg' (large). Default is 'md'.
    */
-  size: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  size: PropTypes.string
 };
 
 export default InputGroup;

--- a/src/components/input/InputGroupText.js
+++ b/src/components/input/InputGroupText.js
@@ -2,19 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBInputGroup from 'react-bootstrap/InputGroup';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use for wrapping text in InputGroups.
  */
 const InputGroupText = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBInputGroup.Text
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBInputGroup.Text>
@@ -56,25 +55,7 @@ InputGroupText.propTypes = {
    *
    * Often used with CSS to style elements with common properties.
    */
-  className: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  className: PropTypes.string
 };
 
 export default InputGroupText;

--- a/src/components/input/RadioButton.js
+++ b/src/components/input/RadioButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {append, includes, without} from 'ramda';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
@@ -23,7 +23,6 @@ const RadioButton = ({
   label_style,
   label_class_name,
   labelClassName,
-  loading_state,
   name,
   setProps,
   disabled = false,
@@ -32,9 +31,7 @@ const RadioButton = ({
   <div
     className={classNames('form-check', class_name || className)}
     style={style}
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
   >
     <input
       id={id}
@@ -167,24 +164,6 @@ RadioButton.propTypes = {
    * Disable the RadioButton.
    **/
   disabled: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/RadioItems.js
+++ b/src/components/input/RadioItems.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {sanitizeOptions} from '../../private/util';
+import {getLoadingState} from '../../private/util';
 
 /**
  * RadioItems is a component that encapsulates several radio item inputs.
@@ -16,7 +17,6 @@ const RadioItems = ({
   class_name,
   style,
   key,
-  loading_state,
   name,
   id,
   inputClassName,
@@ -109,9 +109,7 @@ const RadioItems = ({
       className={class_name || className}
       style={style}
       key={key}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {items}
     </div>
@@ -360,24 +358,6 @@ RadioItems.propTypes = {
    * Set to True to render toggle-like switches instead of radios.
    */
   switch: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/Select.js
+++ b/src/components/input/Select.js
@@ -30,7 +30,7 @@ const Select = ({
   return (
     <RBFormSelect
       {...omit(
-        ['persistence', 'persistence_type', 'persisted_props', 'loading_state'],
+        ['persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
       isInvalid={invalid}

--- a/src/components/input/Switch.js
+++ b/src/components/input/Switch.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {append, includes, without} from 'ramda';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
@@ -23,7 +23,6 @@ const Switch = ({
   label_style,
   label_class_name,
   labelClassName,
-  loading_state,
   name,
   value = false,
   disabled = false,
@@ -32,9 +31,7 @@ const Switch = ({
   <div
     className={classNames('form-check form-switch', class_name || className)}
     style={style}
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
   >
     <input
       id={id}
@@ -166,24 +163,6 @@ Switch.propTypes = {
    * Disable the Switch.
    **/
   disabled: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -2,6 +2,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A basic HTML textarea for entering multiline text based on the corresponding
@@ -14,7 +15,6 @@ const Textarea = ({
   invalid,
   valid,
   size,
-  loading_state,
   autoFocus,
   autofocus,
   maxLength,
@@ -122,9 +122,7 @@ const Textarea = ({
         ['persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     />
   );
 };
@@ -418,24 +416,6 @@ Textarea.propTypes = {
    * has stopped typing for that number of milliseconds
    */
   debounce: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/layout/Col.js
+++ b/src/components/layout/Col.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBCol from 'react-bootstrap/Col';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 const alignMap = {
   start: 'align-self-start',
@@ -32,7 +33,6 @@ const Col = props => {
     align,
     className,
     class_name,
-    loading_state,
     ...otherProps
   } = props;
 
@@ -55,9 +55,7 @@ const Col = props => {
       xxl={xxl}
       className={classes}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBCol>
@@ -192,25 +190,7 @@ Col.propTypes = {
    * Set vertical alignment of this column's content in the parent row. Options
    * are 'start', 'center', 'end', 'stretch', 'baseline'.
    */
-  align: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  align: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline'])
 };
 
 export default Col;

--- a/src/components/layout/Container.js
+++ b/src/components/layout/Container.js
@@ -2,22 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RBContainer from 'react-bootstrap/Container';
 import {omit} from 'ramda';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Containers provide a means to center and horizontally pad your site’s
  * contents.
  */
 const Container = props => {
-  const {children, loading_state, className, class_name, tag, ...otherProps} =
-    props;
+  const {children, className, class_name, tag, ...otherProps} = props;
   return (
     <RBContainer
       as={tag}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBContainer>
@@ -76,25 +74,7 @@ Container.propTypes = {
   /**
    * HTML tag to apply the container class to, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default Container;

--- a/src/components/layout/Row.js
+++ b/src/components/layout/Row.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBRow from 'react-bootstrap/Row';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 const alignMap = {
   start: 'align-items-start',
@@ -28,15 +29,8 @@ const justifyMap = {
  * between columns.
  */
 const Row = props => {
-  const {
-    children,
-    className,
-    class_name,
-    align,
-    justify,
-    loading_state,
-    ...otherProps
-  } = props;
+  const {children, className, class_name, align, justify, ...otherProps} =
+    props;
 
   const alignClass = align && alignMap[align];
   const justifyClass = justify && justifyMap[justify];
@@ -46,9 +40,7 @@ const Row = props => {
     <RBRow
       className={classes}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBRow>
@@ -109,25 +101,7 @@ Row.propTypes = {
     'around',
     'between',
     'evenly'
-  ]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  ])
 };
 
 export default Row;

--- a/src/components/layout/Stack.js
+++ b/src/components/layout/Stack.js
@@ -2,20 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RBStack from 'react-bootstrap/Stack';
 import {omit} from 'ramda';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Stacks are shorthand helpers that build on top of existing flexbox
  * utilities to make component layout faster and easier than ever.
  */
 const Stack = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBStack
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBStack>
@@ -62,24 +61,6 @@ Stack.propTypes = {
    * See https://reactjs.org/docs/lists-and-keys.html for more info
    */
   key: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Which direction to stack the objects in

--- a/src/components/listgroup/ListGroup.js
+++ b/src/components/listgroup/ListGroup.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBListGroup from 'react-bootstrap/ListGroup';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Bootstrap list groups are a flexible way to display a series of content. Use
@@ -11,7 +12,6 @@ import RBListGroup from 'react-bootstrap/ListGroup';
 const ListGroup = props => {
   const {
     children,
-    loading_state,
     className,
     class_name,
     flush,
@@ -26,9 +26,7 @@ const ListGroup = props => {
       as={tag}
       numbered={numbered}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBListGroup>
@@ -83,24 +81,6 @@ ListGroup.propTypes = {
    * edge-to-edge in the parent container (e.g. a Card).
    */
   flush: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Set to True for a horizontal ListGroup, or supply one of the breakpoints

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import RBListGroupItem from 'react-bootstrap/ListGroupItem';
 import Link from '../../private/Link';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Create a single item in a `ListGroup`.
@@ -12,7 +13,6 @@ const ListGroupItem = props => {
     children,
     disabled,
     href,
-    loading_state,
     target,
     setProps,
     color,
@@ -42,9 +42,7 @@ const ListGroupItem = props => {
       style={!isBootstrapColor ? {backgroundColor: color, ...style} : style}
       className={class_name || className}
       {...otherProps}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBListGroupItem>
@@ -136,24 +134,6 @@ ListGroupItem.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Target attribute to pass on to the link. Only applies to external links.

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
 import RBModal from '../../private/Modal';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Create a toggleable dialog using the Modal component. Toggle the visibility
@@ -27,7 +28,6 @@ const Modal = props => {
     backdropClassName,
     backdrop_class_name,
     tag,
-    loading_state,
     fade,
     style,
     zindex,
@@ -66,9 +66,7 @@ const Modal = props => {
         ['persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBModal>

--- a/src/components/modal/ModalBody.js
+++ b/src/components/modal/ModalBody.js
@@ -2,21 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBModalBody from 'react-bootstrap/ModalBody';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use this component to add consistent padding to the body (main content) of
  * your Modals.
  */
 const ModalBody = props => {
-  const {children, loading_state, className, class_name, tag, ...otherProps} =
-    props;
+  const {children, className, class_name, tag, ...otherProps} = props;
   return (
     <RBModalBody
       as={tag}
       className={class_name || className}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -56,25 +54,7 @@ ModalBody.propTypes = {
   /**
    * HTML tag to use for the ModalBody, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default ModalBody;

--- a/src/components/modal/ModalFooter.js
+++ b/src/components/modal/ModalFooter.js
@@ -2,20 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBModalFooter from 'react-bootstrap/ModalFooter';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Add a footer to any modal.
  */
 const ModalFooter = props => {
-  const {children, loading_state, className, class_name, tag, ...otherProps} =
-    props;
+  const {children, className, class_name, tag, ...otherProps} = props;
   return (
     <RBModalFooter
       as={tag}
       className={class_name || className}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -55,25 +53,7 @@ ModalFooter.propTypes = {
   /**
    * HTML tag to use for the ModalFooter, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default ModalFooter;

--- a/src/components/modal/ModalHeader.js
+++ b/src/components/modal/ModalHeader.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBModalHeader from 'react-bootstrap/ModalHeader';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Add a header to any modal.
  */
 const ModalHeader = ({
   children,
-  loading_state,
   className,
   class_name,
   tag,
@@ -19,9 +19,7 @@ const ModalHeader = ({
     as={tag}
     className={class_name || className}
     closeButton={close_button}
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
     {...omit(['setProps'], otherProps)}
   >
     {children}
@@ -65,25 +63,7 @@ ModalHeader.propTypes = {
   /**
    * HTML tag to use for the ModalHeader, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default ModalHeader;

--- a/src/components/modal/ModalTitle.js
+++ b/src/components/modal/ModalTitle.js
@@ -2,20 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBModalTitle from 'react-bootstrap/ModalTitle';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Add a title to any modal. Should be used as a child of the ModalHeader.
  */
 const ModalTitle = props => {
-  const {children, loading_state, className, class_name, tag, ...otherProps} =
-    props;
+  const {children, className, class_name, tag, ...otherProps} = props;
   return (
     <RBModalTitle
       as={tag}
       className={class_name || className}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...omit(['setProps'], otherProps)}
     >
       {children}
@@ -55,25 +53,7 @@ ModalTitle.propTypes = {
   /**
    * HTML tag to use for the ModalTitle, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default ModalTitle;

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNav from 'react-bootstrap/Nav';
 import classNames from 'classnames';
+import {getLoadingState} from '../../private/util';
 
 const horizontalMap = {
   start: 'justify-content-start',
@@ -26,7 +27,6 @@ const verticalMap = {
 const Nav = props => {
   const {
     children,
-    loading_state,
     className,
     class_name,
     pills,
@@ -55,9 +55,7 @@ const Nav = props => {
       justify={justified}
       navbarScroll={navbar_scroll}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBNav>
@@ -146,25 +144,7 @@ Nav.propTypes = {
   /**
    * Enable vertical scrolling within the toggleable contents of a collapsed Navbar.
    */
-  navbar_scroll: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  navbar_scroll: PropTypes.bool
 };
 
 export default Nav;

--- a/src/components/nav/NavItem.js
+++ b/src/components/nav/NavItem.js
@@ -2,19 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNavItem from 'react-bootstrap/NavItem';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Create a single item in a `Nav`.
  */
 const NavItem = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBNavItem
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBNavItem>
@@ -56,25 +55,7 @@ NavItem.propTypes = {
    * performance by React.js while rendering components
    * See https://reactjs.org/docs/lists-and-keys.html for more info
    */
-  key: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  key: PropTypes.string
 };
 
 export default NavItem;

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {History} from '@plotly/dash-component-plugins';
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Add a link to a `Nav`. Can be used as a child of `NavItem` or of `Nav`
@@ -12,7 +13,6 @@ const NavLink = ({
   children,
   className,
   class_name,
-  loading_state,
   setProps,
   href,
   active = false,
@@ -58,9 +58,7 @@ const NavLink = ({
       preOnClick={incrementClicks}
       href={href}
       {...otherProps}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </Link>
@@ -147,24 +145,6 @@ NavLink.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Target attribute to pass on to the link. Only applies to external links.

--- a/src/components/nav/Navbar.js
+++ b/src/components/nav/Navbar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNavbar from 'react-bootstrap/Navbar';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * The Navbar component can be used to make fully customisable navbars.
@@ -10,7 +11,6 @@ import {bootstrapColors} from '../../private/BootstrapColors';
 const Navbar = ({
   children,
   style,
-  loading_state,
   className,
   class_name,
   dark,
@@ -30,9 +30,7 @@ const Navbar = ({
       className={class_name || className}
       expand={expand}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBNavbar>
@@ -126,25 +124,7 @@ Navbar.propTypes = {
   /**
    * Specify screen size at which to expand the menu bar, e.g. sm, md, lg etc.
    */
-  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };
 
 export default Navbar;

--- a/src/components/nav/NavbarBrand.js
+++ b/src/components/nav/NavbarBrand.js
@@ -3,20 +3,19 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNavbarBrand from 'react-bootstrap/NavbarBrand';
 import Link from '../../private/Link';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Call out attention to a brand name or site title within a navbar.
  */
 const NavbarBrand = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBNavbarBrand
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
       as={props.href ? Link : 'span'}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBNavbarBrand>
@@ -72,25 +71,7 @@ NavbarBrand.propTypes = {
   /**
    * URL of the linked resource
    */
-  href: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  href: PropTypes.string
 };
 
 export default NavbarBrand;

--- a/src/components/nav/NavbarSimple.js
+++ b/src/components/nav/NavbarSimple.js
@@ -8,6 +8,7 @@ import {bootstrapColors} from '../../private/BootstrapColors';
 import Nav from './Nav';
 import NavbarBrand from './NavbarBrand';
 import NavbarToggler from './NavbarToggler';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A self-contained navbar ready for use. If you need more customisability try
@@ -22,7 +23,6 @@ const NavbarSimple = props => {
     brand_external_link,
     dark,
     style,
-    loading_state,
     className,
     class_name,
     fluid = false,
@@ -47,9 +47,7 @@ const NavbarSimple = props => {
       className={class_name || className}
       expand={expand}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       <RBContainer fluid={fluid}>
         {brand && (
@@ -185,25 +183,7 @@ NavbarSimple.propTypes = {
    * 'sm', 'md', 'lg', or 'xl'. Below this breakpoint the navbar will collapse
    * and navitems will be placed in a togglable collapse element.
    */
-  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };
 
 export default NavbarSimple;

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBNavbarToggle from 'react-bootstrap/NavbarToggle';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Use this component to create a navbar toggle to show navlinks when the
@@ -9,7 +10,6 @@ import RBNavbarToggle from 'react-bootstrap/NavbarToggle';
  */
 const NavbarToggler = ({
   children,
-  loading_state,
   className,
   class_name,
   n_clicks = 0,
@@ -25,9 +25,7 @@ const NavbarToggler = ({
       }}
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBNavbarToggle>
@@ -79,25 +77,7 @@ NavbarToggler.propTypes = {
    * An integer that represents the number of times
    * that this element has been clicked on.
    */
-  n_clicks: PropTypes.number,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  n_clicks: PropTypes.number
 };
 
 export default NavbarToggler;

--- a/src/components/offcanvas/Offcanvas.js
+++ b/src/components/offcanvas/Offcanvas.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RBOffcanvas from 'react-bootstrap/Offcanvas';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Create a toggleable hidden sidebar using the Offcanvas component.
@@ -9,7 +10,6 @@ import RBOffcanvas from 'react-bootstrap/Offcanvas';
 const Offcanvas = ({
   setProps,
   children,
-  loading_state,
   class_name,
   className,
   backdrop_class_name,
@@ -51,9 +51,7 @@ const Offcanvas = ({
       show={is_open}
       onHide={backdrop !== 'static' ? onHide : null}
       backdrop={backdrop || backdrop === 'static'}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...otherProps}
     >
       {header}
@@ -163,25 +161,7 @@ Offcanvas.propTypes = {
    * Specify whether the Component should contain a close button
    * in the header
    */
-  close_button: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  close_button: PropTypes.bool
 };
 
 export default Offcanvas;

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RBPagination from 'react-bootstrap/Pagination';
+import {getLoadingState} from '../../private/util';
 
 /**
  * The container for presentational components for building a pagination UI.
@@ -11,7 +12,6 @@ const Pagination = ({
   setProps,
   class_name,
   className,
-  loading_state,
   min_value = 1,
   step = 1,
   active_page = 1,
@@ -139,9 +139,7 @@ const Pagination = ({
   return (
     <RBPagination
       className={class_name || className}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...otherProps}
     >
       {paginationItems}
@@ -217,25 +215,7 @@ Pagination.propTypes = {
    * When True, this will display a first and last icon at the beginning
    * and end of the component.
    */
-  first_last: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  first_last: PropTypes.bool
 };
 
 export default Pagination;

--- a/src/components/placeholder/Placeholder.js
+++ b/src/components/placeholder/Placeholder.js
@@ -11,7 +11,6 @@ import classNames from 'classnames';
  */
 const Placeholder = ({
   children,
-  loading_state,
   className,
   class_name,
   color,
@@ -26,40 +25,39 @@ const Placeholder = ({
   const [showPlaceholder, setShowPlaceholder] = useState(show_initially);
   const dismissTimer = useRef();
   const showTimer = useRef();
+  const loading = getLoadingState();
 
   useEffect(() => {
-    if (loading_state) {
-      if (loading_state.is_loading) {
-        // if component is currently loading and there's a dismiss timer active
-        // we need to clear it.
-        if (dismissTimer.current) {
-          dismissTimer.current = clearTimeout(dismissTimer.current);
-        }
-        // if component is currently loading but the placeholder is not showing and
-        // there is no timer set to show, then set a timeout to show
-        if (!showPlaceholder && !showTimer.current) {
-          showTimer.current = setTimeout(() => {
-            setShowPlaceholder(true);
-            showTimer.current = null;
-          }, delay_show);
-        }
-      } else {
-        // if component is not currently loading and there's a show timer
-        // active we need to clear it
-        if (showTimer.current) {
-          showTimer.current = clearTimeout(showTimer.current);
-        }
-        // if component is not currently loading and the placeholder is showing and
-        // there's no timer set to dismiss it, then set a timeout to hide it
-        if (showPlaceholder && !dismissTimer.current) {
-          dismissTimer.current = setTimeout(() => {
-            setShowPlaceholder(false);
-            dismissTimer.current = null;
-          }, delay_hide);
-        }
+    if (loading) {
+      // if component is currently loading and there's a dismiss timer active
+      // we need to clear it.
+      if (dismissTimer.current) {
+        dismissTimer.current = clearTimeout(dismissTimer.current);
+      }
+      // if component is currently loading but the placeholder is not showing and
+      // there is no timer set to show, then set a timeout to show
+      if (!showPlaceholder && !showTimer.current) {
+        showTimer.current = setTimeout(() => {
+          setShowPlaceholder(true);
+          showTimer.current = null;
+        }, delay_show);
+      }
+    } else {
+      // if component is not currently loading and there's a show timer
+      // active we need to clear it
+      if (showTimer.current) {
+        showTimer.current = clearTimeout(showTimer.current);
+      }
+      // if component is not currently loading and the placeholder is showing and
+      // there's no timer set to dismiss it, then set a timeout to hide it
+      if (showPlaceholder && !dismissTimer.current) {
+        dismissTimer.current = setTimeout(() => {
+          setShowPlaceholder(false);
+          dismissTimer.current = null;
+        }, delay_hide);
       }
     }
-  }, [delay_hide, delay_show, loading_state]);
+  }, [delay_hide, delay_show, loading]);
 
   // If the placeholder is to be animated, need to add the placeholder class
   // (as this isn't added for some reason)
@@ -177,24 +175,6 @@ Placeholder.propTypes = {
   key: PropTypes.string,
 
   /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
-
-  /**
    * Changes the animation of the placeholder.
    */
   animation: PropTypes.oneOf(['glow', 'wave']),
@@ -223,8 +203,7 @@ Placeholder.propTypes = {
 
   /**
    * When using the placeholder as a loading placeholder, add a time delay
-   * (in ms) to the placeholder being shown after the loading_state is set to
-   * true.
+   * (in ms) to the placeholder being shown after the lcomponent starts loading.
    */
   delay_show: PropTypes.number,
 

--- a/src/components/placeholder/Placeholder.js
+++ b/src/components/placeholder/Placeholder.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import RBPlaceholder from 'react-bootstrap/Placeholder';
-import {omit} from 'ramda';
+import {equals, omit} from 'ramda';
 
 import {loadingSelector} from '../../private/util';
 
@@ -26,11 +26,13 @@ const Placeholder = ({
   target_components,
   ...otherProps
 }) => {
-  const ctx = window.dash_component_api.useDashContext();
-  const loading = ctx.useSelector(
-    loadingSelector(ctx.componentPath, target_components),
-    equals
-  );
+  const ctx = window.dash_component_api?.useDashContext();
+  const loading = ctx
+    ? ctx.useSelector(
+        loadingSelector(ctx.componentPath, target_components),
+        equals
+      )
+    : false;
 
   const [showPlaceholder, setShowPlaceholder] = useState(show_initially);
   const dismissTimer = useRef();

--- a/src/components/placeholder/__tests__/Placeholder.test.js
+++ b/src/components/placeholder/__tests__/Placeholder.test.js
@@ -9,6 +9,19 @@ import Placeholder from '../Placeholder';
 jest.useFakeTimers();
 
 describe('Placeholder', () => {
+  beforeEach(() => {
+    window.dash_component_api = {
+      useDashContext: jest.fn(() => ({
+        componentPath: [0],
+        useSelector: jest.fn(() => false) // Default behavior
+      }))
+    };
+  });
+
+  afterEach(() => {
+    delete window.dash_component_api;
+  });
+
   test('renders a span with class "placeholder"', () => {
     const placeholder = render(<Placeholder />);
 
@@ -27,9 +40,7 @@ describe('Placeholder', () => {
 
   test("renders its content if object isn't loading", () => {
     const {container: container, rerender} = render(
-      <Placeholder loading_state={{is_loading: false}}>
-        Some placeholder content
-      </Placeholder>
+      <Placeholder>Some placeholder content</Placeholder>
     );
 
     // placeholder is initially visible until we've had time to update based on
@@ -39,14 +50,12 @@ describe('Placeholder', () => {
     expect(container).toHaveTextContent('Some placeholder content');
     expect(container.querySelector('span.placeholder')).toBe(null);
 
-    rerender(
-      <Placeholder loading_state={{is_loading: true}}>
-        Some placeholder content
-      </Placeholder>
-    );
+    window.dash_component_api.useDashContext.mockImplementation(() => ({
+      componentPath: [0],
+      useSelector: jest.fn(() => true)
+    }));
 
-    const overAll = container.firstChild;
-    const placeholder = overAll.lastChild;
+    rerender(<Placeholder>Some placeholder content</Placeholder>);
 
     act(() => jest.advanceTimersByTime(10));
 
@@ -101,7 +110,7 @@ describe('Placeholder', () => {
         firstChild: {lastChild: placeholderGlow}
       }
     } = render(
-      <Placeholder animation="glow" loading_state={{is_loading: true}}>
+      <Placeholder animation="glow">
         <p>Child</p>
       </Placeholder>
     );
@@ -115,7 +124,7 @@ describe('Placeholder', () => {
         firstChild: {lastChild: placeholderSm}
       }
     } = render(
-      <Placeholder size="sm" loading_state={{is_loading: true}}>
+      <Placeholder size="sm">
         <p>Child</p>
       </Placeholder>
     );
@@ -128,10 +137,7 @@ describe('Placeholder', () => {
         firstChild: {lastChild: placeholderStyle}
       }
     } = render(
-      <Placeholder
-        style={{width: '5rem', height: '5rem'}}
-        loading_state={{is_loading: true}}
-      >
+      <Placeholder style={{width: '5rem', height: '5rem'}}>
         <p>Child</p>
       </Placeholder>
     );
@@ -156,5 +162,32 @@ describe('Placeholder', () => {
     expect(placeholderPrimary).toHaveClass('bg-primary');
     expect(placeholderSuccess).toHaveClass('bg-success');
     expect(placeholderDark).toHaveClass('bg-dark');
+  });
+
+  test('display prop overrides loading state', () => {
+    const {container: container, rerender} = render(
+      <Placeholder display="show">Some placeholder content</Placeholder>
+    );
+
+    // placeholder is initially visible until we've had time to update based on
+    // loading state. this can be disabled with show_initially={false}
+    act(() => jest.advanceTimersByTime(10));
+
+    expect(container).toHaveTextContent('Some placeholder content');
+    expect(container.querySelector('span.placeholder')).not.toBe(null);
+
+    window.dash_component_api.useDashContext.mockImplementation(() => ({
+      componentPath: [0],
+      useSelector: jest.fn(() => true)
+    }));
+
+    rerender(
+      <Placeholder display="hide">Some placeholder content</Placeholder>
+    );
+
+    act(() => jest.advanceTimersByTime(10));
+
+    expect(container).toHaveTextContent('Some placeholder content');
+    expect(container.querySelector('span.placeholder')).toBe(null);
   });
 });

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -4,6 +4,7 @@ import {omit} from 'ramda';
 
 import {PopoverTemplate} from '../../private/OverlayTemplates';
 import Overlay from '../../private/Overlay';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Popover creates a toggleable overlay that can be used to provide additional
@@ -18,7 +19,6 @@ const Popover = props => {
   const {
     children,
     is_open,
-    loading_state,
     className,
     class_name,
     style,
@@ -52,9 +52,7 @@ const Popover = props => {
 
   return (
     <Overlay
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       defaultShow={is_open}
       popperConfig={popperConfig}
       delay={delay}
@@ -223,24 +221,6 @@ Popover.propTypes = {
    * Optionally hide popover when hovering over content - default False.
    */
   autohide: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/popover/PopoverBody.js
+++ b/src/components/popover/PopoverBody.js
@@ -2,19 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBPopoverBody from 'react-bootstrap/PopoverBody';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Componnet for wrapping the body (i.e. main content) of a `Popover`.
  */
 const PopoverBody = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBPopoverBody
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBPopoverBody>
@@ -60,25 +59,7 @@ PopoverBody.propTypes = {
   /**
    * HTML tag to use for the PopoverBody, default: div
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default PopoverBody;

--- a/src/components/popover/PopoverHeader.js
+++ b/src/components/popover/PopoverHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
+import RBPopoverHeader from 'react-bootstrap/PopoverHeader';
 import {getLoadingState} from '../../private/util';
 
 /**

--- a/src/components/popover/PopoverHeader.js
+++ b/src/components/popover/PopoverHeader.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
-import RBPopoverHeader from 'react-bootstrap/PopoverHeader';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Creates a header for use inside the `Popover` component.
  */
 const PopoverHeader = props => {
-  const {children, loading_state, className, class_name, ...otherProps} = props;
+  const {children, className, class_name, ...otherProps} = props;
   return (
     <RBPopoverHeader
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBPopoverHeader>
@@ -60,25 +58,7 @@ PopoverHeader.propTypes = {
   /**
    * HTML tag to use for the PopoverHeader, default: h3
    */
-  tag: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  tag: PropTypes.string
 };
 
 export default PopoverHeader;

--- a/src/components/progress/Progress.js
+++ b/src/components/progress/Progress.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {map} from 'react-bootstrap/ElementChildren';
 import {omit} from 'ramda';
+import {getLoadingState} from '../../private/util';
 
 import {bootstrapColors} from '../../private/BootstrapColors';
 
@@ -119,7 +120,6 @@ const ProgressBar = React.forwardRef(
 
 const Progress = ({
   children,
-  loading_state,
   color,
   className,
   class_name,
@@ -133,9 +133,7 @@ const Progress = ({
     <ProgressBar
       className={class_name || className}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       now={value}
       isChild={bar}
       variant={isBootstrapColor ? color : null}
@@ -230,25 +228,7 @@ Progress.propTypes = {
    * warning, danger, info or any valid CSS color
    * of your choice (e.g. a hex code, a decimal code or a CSS color name).
    */
-  color: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  color: PropTypes.string
 };
 
 export default Progress;

--- a/src/components/spinner/Spinner.js
+++ b/src/components/spinner/Spinner.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBSpinner from 'react-bootstrap/Spinner';
 import {bootstrapColors} from '../../private/BootstrapColors';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Render Bootstrap style loading spinners using only CSS.
@@ -15,7 +16,6 @@ const Spinner = props => {
   const {
     children,
     color,
-    loading_state,
     spinner_style,
     spinnerClassName,
     spinner_class_name,
@@ -33,40 +33,39 @@ const Spinner = props => {
   const [showSpinner, setShowSpinner] = useState(show_initially);
   const dismissTimer = useRef();
   const showTimer = useRef();
+  const loading = getLoadingState();
 
   useEffect(() => {
-    if (loading_state) {
-      if (loading_state.is_loading) {
-        // if component is currently loading and there's a dismiss timer active
-        // we need to clear it.
-        if (dismissTimer.current) {
-          dismissTimer.current = clearTimeout(dismissTimer.current);
-        }
-        // if component is currently loading but the spinner is not showing and
-        // there is no timer set to show, then set a timeout to show
-        if (!showSpinner && !showTimer.current) {
-          showTimer.current = setTimeout(() => {
-            setShowSpinner(true);
-            showTimer.current = null;
-          }, delay_show);
-        }
-      } else {
-        // if component is not currently loading and there's a show timer
-        // active we need to clear it
-        if (showTimer.current) {
-          showTimer.current = clearTimeout(showTimer.current);
-        }
-        // if component is not currently loading and the spinner is showing and
-        // there's no timer set to dismiss it, then set a timeout to hide it
-        if (showSpinner && !dismissTimer.current) {
-          dismissTimer.current = setTimeout(() => {
-            setShowSpinner(false);
-            dismissTimer.current = null;
-          }, delay_hide);
-        }
+    if (loading) {
+      // if component is currently loading and there's a dismiss timer active
+      // we need to clear it.
+      if (dismissTimer.current) {
+        dismissTimer.current = clearTimeout(dismissTimer.current);
+      }
+      // if component is currently loading but the spinner is not showing and
+      // there is no timer set to show, then set a timeout to show
+      if (!showSpinner && !showTimer.current) {
+        showTimer.current = setTimeout(() => {
+          setShowSpinner(true);
+          showTimer.current = null;
+        }, delay_show);
+      }
+    } else {
+      // if component is not currently loading and there's a show timer
+      // active we need to clear it
+      if (showTimer.current) {
+        showTimer.current = clearTimeout(showTimer.current);
+      }
+      // if component is not currently loading and the spinner is showing and
+      // there's no timer set to dismiss it, then set a timeout to hide it
+      if (showSpinner && !dismissTimer.current) {
+        dismissTimer.current = setTimeout(() => {
+          setShowSpinner(false);
+          dismissTimer.current = null;
+        }, delay_hide);
       }
     }
-  }, [delay_hide, delay_show, loading_state]);
+  }, [delay_hide, delay_show, loading]);
 
   const isBootstrapColor = bootstrapColors.has(color);
 
@@ -151,8 +150,6 @@ const Spinner = props => {
   return <SpinnerDiv style={spinner_style} />;
 };
 
-Spinner._dashprivate_isLoadingComponent = true;
-
 Spinner.propTypes = {
   /**
    * The ID of this component, used to identify dash components
@@ -234,7 +231,7 @@ Spinner.propTypes = {
 
   /**
    * When using the spinner as a loading spinner, add a time delay (in ms) to
-   * the spinner being shown after the loading_state is set to true.
+   * the spinner being shown after the component starts loading.
    */
   delay_show: PropTypes.number,
 

--- a/src/components/spinner/Spinner.js
+++ b/src/components/spinner/Spinner.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
+import {equals, omit} from 'ramda';
 import RBSpinner from 'react-bootstrap/Spinner';
 import {bootstrapColors} from '../../private/BootstrapColors';
 import {loadingSelector} from '../../private/util';
@@ -31,11 +31,13 @@ const Spinner = props => {
     display,
     ...otherProps
   } = props;
-  const ctx = window.dash_component_api.useDashContext();
-  const loading = ctx.useSelector(
-    loadingSelector(ctx.componentPath, target_components),
-    equals
-  );
+  const ctx = window.dash_component_api?.useDashContext();
+  const loading = ctx
+    ? ctx.useSelector(
+        loadingSelector(ctx.componentPath, target_components),
+        equals
+      )
+    : false;
 
   const [showSpinner, setShowSpinner] = useState(show_initially);
   const dismissTimer = useRef();

--- a/src/components/spinner/__tests__/Spinner.test.js
+++ b/src/components/spinner/__tests__/Spinner.test.js
@@ -9,6 +9,19 @@ import Spinner from '../Spinner';
 jest.useFakeTimers();
 
 describe('Spinner', () => {
+  beforeEach(() => {
+    window.dash_component_api = {
+      useDashContext: jest.fn(() => ({
+        componentPath: [0],
+        useSelector: jest.fn(() => false) // Default behavior
+      }))
+    };
+  });
+
+  afterEach(() => {
+    delete window.dash_component_api;
+  });
+
   test('renders a div with class "border-spinner"', () => {
     const spinner = render(<Spinner />);
 
@@ -19,9 +32,7 @@ describe('Spinner', () => {
 
   test("renders its content if object isn't loading", () => {
     const {container: container, rerender} = render(
-      <Spinner loading_state={{is_loading: false}}>
-        Some spinner content
-      </Spinner>
+      <Spinner>Some spinner content</Spinner>
     );
 
     // spinner is initially visible until we've had time to update based on
@@ -31,12 +42,12 @@ describe('Spinner', () => {
     expect(container).toHaveTextContent('Some spinner content');
     expect(container.querySelector('div.spinner-border')).toBe(null);
 
-    rerender(
-      <Spinner loading_state={{is_loading: true}}>Some spinner content</Spinner>
-    );
+    window.dash_component_api.useDashContext.mockImplementation(() => ({
+      componentPath: [0],
+      useSelector: jest.fn(() => true)
+    }));
 
-    const overAll = container.firstChild;
-    const spinner = overAll.lastChild;
+    rerender(<Spinner>Some spinner content</Spinner>);
 
     act(() => jest.advanceTimersByTime(10));
 
@@ -163,6 +174,31 @@ describe('Spinner', () => {
 
     act(() => jest.advanceTimersByTime(1000));
 
+    expect(container.querySelector('div.spinner-border')).toBe(null);
+  });
+
+  test('display prop overrides loading state', () => {
+    const {container: container, rerender} = render(
+      <Spinner display="show">Some spinner content</Spinner>
+    );
+
+    // spinner is initially visible until we've had time to update based on
+    // loading state. this can be disabled with show_initially={false}
+    act(() => jest.advanceTimersByTime(10));
+
+    expect(container).toHaveTextContent('Some spinner content');
+    expect(container.querySelector('div.spinner-border')).not.toBe(null);
+
+    window.dash_component_api.useDashContext.mockImplementation(() => ({
+      componentPath: [0],
+      useSelector: jest.fn(() => true)
+    }));
+
+    rerender(<Spinner display="hide">Some spinner content</Spinner>);
+
+    act(() => jest.advanceTimersByTime(10));
+
+    expect(container).toHaveTextContent('Some spinner content');
     expect(container.querySelector('div.spinner-border')).toBe(null);
   });
 });

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import RBTable from 'react-bootstrap/Table';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for applying Bootstrap styles to HTML tables. Use this as a
@@ -9,23 +10,13 @@ import RBTable from 'react-bootstrap/Table';
  * DataFrame using `dbc.Table.from_dataframe`.
  */
 const Table = props => {
-  const {
-    children,
-    loading_state,
-    className,
-    class_name,
-    color,
-    dark,
-    ...otherProps
-  } = props;
+  const {children, className, class_name, color, dark, ...otherProps} = props;
   return (
     <RBTable
       className={class_name || className}
       variant={color || (dark ? 'dark' : undefined)}
       {...omit(['setProps'], otherProps)}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       {children}
     </RBTable>
@@ -115,25 +106,7 @@ Table.propTypes = {
    * Set to True or one of the breakpoints 'sm', 'md', 'lg', 'xl' to make table
    * scroll horizontally at lower breakpoints.
    */
-  responsive: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  responsive: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };
 
 export default Table;

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -146,25 +146,7 @@ Tab.propTypes = {
   /**
    * Determines if tab is disabled or not - defaults to false
    */
-  disabled: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  disabled: PropTypes.bool
 };
 
 export default Tab;

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -4,6 +4,7 @@ import {omit} from 'ramda';
 import classnames from 'classnames';
 import RBNav from 'react-bootstrap/Nav';
 import RBTab from 'react-bootstrap/Tab';
+import {getLoadingState} from '../../private/util';
 
 import {
   parseChildrenToArray,
@@ -23,7 +24,6 @@ const Tabs = ({
   style,
   active_tab,
   key,
-  loading_state,
   setProps
 }) => {
   children = parseChildrenToArray(children);
@@ -117,7 +117,6 @@ const Tabs = ({
         label_class_name,
         activeLabelClassName,
         active_label_class_name,
-        loading_state,
         disabled = false,
         ...otherProps
       } = childProps;
@@ -132,9 +131,7 @@ const Tabs = ({
             ['setProps', 'persistence', 'persistence_type', 'persisted_props'],
             otherProps
           )}
-          data-dash-is-loading={
-            (loading_state && loading_state.is_loading) || undefined
-          }
+          data-dash-is-loading={getLoadingState() || undefined}
         >
           {child}
         </RBTab.Pane>
@@ -145,9 +142,7 @@ const Tabs = ({
       key={key}
       activeKey={active_tab}
       onSelect={id => setProps({active_tab: id})}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
     >
       <RBNav
         id={id}
@@ -211,24 +206,6 @@ Tabs.propTypes = {
    * (starting from 0) of the tab.
    */
   active_tab: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {omit} from 'ramda';
 import RBToast from 'react-bootstrap/Toast';
+import {getLoadingState} from '../../private/util';
 
 /**
  * Toasts can be used to push messages and notifactions to users. Control
@@ -12,7 +13,6 @@ import RBToast from 'react-bootstrap/Toast';
 const Toast = props => {
   const {
     children,
-    loading_state,
     header,
     icon,
     header_style,
@@ -58,9 +58,7 @@ const Toast = props => {
       onClose={dismissable && dismiss}
       className={class_name || className}
       bg={color}
-      data-dash-is-loading={
-        (loading_state && loading_state.is_loading) || undefined
-      }
+      data-dash-is-loading={getLoadingState() || undefined}
       {...omit(
         ['persistence', 'persisted_props', 'persistence_type', 'setProps'],
         otherProps
@@ -224,24 +222,6 @@ Toast.propTypes = {
    * light, dark. Default: secondary.
    */
   color: PropTypes.string,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  }),
 
   /**
    * Used to allow user interactions in this component to be persisted when

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 
 import {TooltipTemplate} from '../../private/OverlayTemplates';
 import Overlay from '../../private/Overlay';
+import {getLoadingState} from '../../private/util';
 
 /**
  * A component for adding tooltips to any element, no callbacks required!
@@ -16,7 +16,6 @@ const Tooltip = ({
   id,
   children,
   is_open,
-  loading_state,
   className,
   class_name,
   style,
@@ -29,9 +28,7 @@ const Tooltip = ({
   ...otherProps
 }) => (
   <Overlay
-    data-dash-is-loading={
-      (loading_state && loading_state.is_loading) || undefined
-    }
+    data-dash-is-loading={getLoadingState() || undefined}
     defaultShow={is_open}
     delay={delay}
     placement={placement}
@@ -151,25 +148,7 @@ Tooltip.propTypes = {
   /**
    * Whether the Tooltip is open or not.
    */
-  is_open: PropTypes.bool,
-
-  /**
-   * Object that holds the loading state object coming from dash-renderer
-   */
-  loading_state: PropTypes.shape({
-    /**
-     * Determines if the component is loading or not
-     */
-    is_loading: PropTypes.bool,
-    /**
-     * Holds which property is loading
-     */
-    prop_name: PropTypes.string,
-    /**
-     * Holds the name of the component that is loading
-     */
-    component_name: PropTypes.string
-  })
+  is_open: PropTypes.bool
 };
 
 export default Tooltip;

--- a/src/private/util.js
+++ b/src/private/util.js
@@ -73,4 +73,18 @@ const stringifyId = id => {
   return '{' + parts.join(',') + '}';
 };
 
-export {parseChildrenToArray, resolveChildProps, sanitizeOptions, stringifyId};
+const getLoadingState = () => {
+  const ctx = window.dash_component_api?.useDashContext();
+  if (ctx) {
+    return ctx.useLoading();
+  }
+  return false;
+};
+
+export {
+  getLoadingState,
+  parseChildrenToArray,
+  resolveChildProps,
+  sanitizeOptions,
+  stringifyId
+};

--- a/src/private/util.js
+++ b/src/private/util.js
@@ -1,4 +1,4 @@
-import {type} from 'ramda';
+import {any, concat, includes, toPairs, type} from 'ramda';
 
 const parseChildrenToArray = children => {
   if (children && !Array.isArray(children)) {
@@ -11,16 +11,15 @@ const parseChildrenToArray = children => {
 
 const resolveChildProps = child => {
   // This may need to change in the future if https://github.com/plotly/dash-renderer/issues/84 is addressed
-  if (
-    child.props._dashprivate_layout &&
-    child.props._dashprivate_layout.props
-  ) {
+  if (child.props.componentPath) {
     // props are coming from Dash
-    return child.props._dashprivate_layout.props;
-  } else {
-    // else props are coming from React (e.g. Demo.js, or Tabs.test.js)
-    return child.props;
+    return window.dash_component_api.getLayout([
+      ...child.props.componentPath,
+      'props'
+    ]);
   }
+  // else props are coming from React (e.g. Demo.js, or Tabs.test.js)
+  return child.props;
 };
 
 const sanitizeOptions = options => {
@@ -81,8 +80,41 @@ const getLoadingState = () => {
   return false;
 };
 
+// vendored from dcc.Loading
+const loadingSelector = (componentPath, targetComponents) => state => {
+  let stringPath = JSON.stringify(componentPath);
+  // Remove the last ] for easy match
+  stringPath = stringPath.substring(0, stringPath.length - 1);
+  const loadingChildren = toPairs(state.loading).reduce((acc, [path, load]) => {
+    if (path.startsWith(stringPath) && load.length) {
+      if (
+        targetComponents &&
+        !any(l => {
+          const target = targetComponents[l.id];
+          if (!target) {
+            return false;
+          }
+          if (Array.isArray(target)) {
+            return includes(l.property, target);
+          }
+          return l.property === target;
+        }, load)
+      ) {
+        return acc;
+      }
+      return concat(acc, load);
+    }
+    return acc;
+  }, []);
+  if (loadingChildren.length) {
+    return loadingChildren;
+  }
+  return null;
+};
+
 export {
   getLoadingState,
+  loadingSelector,
   parseChildrenToArray,
   resolveChildProps,
   sanitizeOptions,


### PR DESCRIPTION
Dash 3.0 changes how loading state works. This PR

- [x] Updates the two loading components we have: `Spinner` and `Placeholder`
- [x] Removes `loading_state` throughout
- [x] Brings `Spinner` and `Placeholder` in line with Dash 3.0 interface (should we do this??)
- [ ] add tests for target components
- [ ] update docs