### PR TITLE
Remove`*_timestamp` props

### DIFF
--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -20,16 +20,12 @@ const Badge = props => {
     text_color,
     color = 'secondary',
     n_clicks = 0,
-    n_clicks_timestamp = -1,
     ...otherProps
   } = props;
 
   const incrementClicks = () => {
     if (setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
   const isBootstrapColor = bootstrapColors.has(color);
@@ -155,13 +151,6 @@ Badge.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Target attribute to pass on to the link. Only applies to external links.

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 import RBButton from 'react-bootstrap/Button';
 import Link from '../../private/Link';
 
@@ -34,10 +33,7 @@ const Button = ({
 }) => {
   const incrementClicks = () => {
     if (!disabled && setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
   const useLink = href && !disabled;
@@ -61,7 +57,7 @@ const Button = ({
       value={useLink ? undefined : value}
       className={class_name || className}
       rel={useLink ? rel : undefined}
-      {...omit(['n_clicks_timestamp'], otherProps)}
+      {...otherProps}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
@@ -128,16 +124,6 @@ Button.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * Use of *_timestamp props has been deprecated in Dash in favour of dash.callback_context.
-   * See "How do I determine which Input has changed?" in the Dash FAQs https://dash.plot.ly/faqs.
-   *
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Whether button is in active state. Default: False.

--- a/src/components/card/CardLink.js
+++ b/src/components/card/CardLink.js
@@ -19,10 +19,7 @@ const CardLink = ({
 }) => {
   const incrementClicks = () => {
     if (!disabled && setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
 
@@ -99,13 +96,6 @@ CardLink.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/dropdownmenu/DropdownMenuItem.js
+++ b/src/components/dropdownmenu/DropdownMenuItem.js
@@ -21,7 +21,6 @@ const DropdownMenuItem = ({
   header,
   divider,
   n_clicks = 0,
-  n_clicks_timestamp = -1,
   toggle = true,
   ...otherProps
 }) => {
@@ -29,10 +28,7 @@ const DropdownMenuItem = ({
 
   const handleClick = e => {
     if (!disabled && setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
     if (toggle && context.isOpen) {
       context.toggle(e);
@@ -149,13 +145,6 @@ DropdownMenuItem.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 import RBForm from 'react-bootstrap/Form';
 
 /**
@@ -15,7 +14,6 @@ const Form = ({
   class_name,
   prevent_default_on_submit = true,
   n_submit = 0,
-  n_submit_timestamp = -1,
   ...otherProps
 }) => {
   return (
@@ -25,10 +23,7 @@ const Form = ({
           e.preventDefault();
         }
         if (setProps) {
-          setProps({
-            n_submit: n_submit + 1,
-            n_submit_timestamp: Date.now()
-          });
+          setProps({n_submit: n_submit + 1});
         }
       }}
       className={class_name || className}
@@ -94,11 +89,6 @@ Form.propTypes = {
    * Number of times the `Enter` key was pressed while the input had focus.
    */
   n_submit: PropTypes.number,
-
-  /**
-   * Last time that `Enter` was pressed.
-   */
-  n_submit_timestamp: PropTypes.number,
 
   /**
    * The form calls preventDefault on submit events. If you want form data to

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -116,10 +116,7 @@ const Input = ({
 
   const onBlur = () => {
     if (setProps) {
-      const payload = {
-        n_blur: n_blur + 1,
-        n_blur_timestamp: Date.now()
-      };
+      const payload = {n_blur: n_blur + 1};
       if (debounce === true) {
         // numeric debounce here has no effect, we only care about boolean debounce
         onEvent(payload);
@@ -131,10 +128,7 @@ const Input = ({
 
   const onKeyUp = e => {
     if (setProps && e.key === 'Enter') {
-      const payload = {
-        n_submit: n_submit + 1,
-        n_submit_timestamp: Date.now()
-      };
+      const payload = {n_submit: n_submit + 1};
       if (debounce === true) {
         // numeric debounce here has no effect, we only care about boolean debounce
         onEvent(payload);
@@ -153,13 +147,7 @@ const Input = ({
       onBlur={onBlur}
       onKeyUp={onKeyUp}
       {...omit(
-        [
-          'n_blur_timestamp',
-          'n_submit_timestamp',
-          'persistence',
-          'persistence_type',
-          'persisted_props'
-        ],
+        ['persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
       valid={valid ? 'true' : undefined}
@@ -586,19 +574,9 @@ Input.propTypes = {
   n_submit: PropTypes.number,
 
   /**
-   * Last time that `Enter` was pressed.
-   */
-  n_submit_timestamp: PropTypes.number,
-
-  /**
    * Number of times the input lost focus.
    */
   n_blur: PropTypes.number,
-
-  /**
-   * Last time the input lost focus.
-   */
-  n_blur_timestamp: PropTypes.number,
 
   /**
    * If true, changes to input will be sent back to the Dash server

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -34,11 +34,8 @@ const Textarea = ({
   tabIndex,
   tabindex,
   n_blur = 0,
-  n_blur_timestamp = -1,
   n_submit = 0,
-  n_submit_timestamp = -1,
   n_clicks = 0,
-  n_clicks_timestamp = -1,
   debounce = false,
   value = '',
   submit_on_enter = true,
@@ -71,10 +68,7 @@ const Textarea = ({
 
   const onBlur = e => {
     if (setProps) {
-      const payload = {
-        n_blur: n_blur + 1,
-        n_blur_timestamp: Date.now()
-      };
+      const payload = {n_blur: n_blur + 1};
       if (debounce === true) {
         payload.value = e.target.value;
       }
@@ -85,10 +79,7 @@ const Textarea = ({
   const onKeyUp = e => {
     if (submit_on_enter && setProps && e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault(); // don't create newline if submitting
-      const payload = {
-        n_submit: n_submit + 1,
-        n_submit_timestamp: Date.now()
-      };
+      const payload = {n_submit: n_submit + 1};
       if (debounce === true) {
         payload.value = e.target.value;
       }
@@ -98,10 +89,7 @@ const Textarea = ({
 
   const onClick = () => {
     if (setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
 
@@ -131,13 +119,7 @@ const Textarea = ({
       spellCheck={spellcheck || spellCheck}
       tabIndex={tabindex || tabIndex}
       {...omit(
-        [
-          'n_blur_timestamp',
-          'n_submit_timestamp',
-          'persistence',
-          'persistence_type',
-          'persisted_props'
-        ],
+        ['persistence', 'persistence_type', 'persisted_props'],
         otherProps
       )}
       data-dash-is-loading={
@@ -410,10 +392,6 @@ Textarea.propTypes = {
    * Number of times the input lost focus.
    */
   n_blur: PropTypes.number,
-  /**
-   * Last time the input lost focus.
-   */
-  n_blur_timestamp: PropTypes.number,
 
   /**
    * Number of times the `Enter` key was pressed while the textarea had focus. Only
@@ -422,13 +400,8 @@ Textarea.propTypes = {
   n_submit: PropTypes.number,
 
   /**
-   * Last time that `Enter` was pressed. Only updates if submit_on_enter is True.
-   */
-  n_submit_timestamp: PropTypes.number,
-
-  /**
-   * Whether or not the form should increment the n_submit and n_submit_timestamp props
-   * when enter key is pressed. If True, use shift + enter to create a newline. Default: True
+   * Whether or not the form should increment the n_submit prop when enter key is
+   * pressed. If True, use shift + enter to create a newline. Default: True
    */
   submit_on_enter: PropTypes.bool,
 
@@ -437,13 +410,6 @@ Textarea.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * If true, changes to input will be sent back to the Dash server only on enter or

--- a/src/components/input/__tests__/Input.test.js
+++ b/src/components/input/__tests__/Input.test.js
@@ -113,30 +113,22 @@ describe('Input', () => {
       expect(call3).toEqual([{value: 'abc'}]);
     });
 
-    test('track number of blurs with "n_blur" and "n_blur_timestamp"', () => {
-      const before = Date.now();
+    test('track number of blurs with "n_blur"', () => {
       fireEvent.blur(inputElement);
-      const after = Date.now();
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_blur, n_blur_timestamp}]] = mockSetProps.mock.calls;
+      const [[{n_blur}]] = mockSetProps.mock.calls;
       expect(n_blur).toEqual(1);
-      expect(n_blur_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_blur_timestamp).toBeLessThanOrEqual(after);
     });
 
-    test('tracks submit with "n_submit" and "n_submit_timestamp"', () => {
-      const before = Date.now();
+    test('tracks submit with "n_submit"', () => {
       fireEvent.keyUp(inputElement, {key: 'Enter', code: 13, charCode: 13});
-      const after = Date.now();
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_submit, n_submit_timestamp}]] = mockSetProps.mock.calls;
+      const [[{n_submit}]] = mockSetProps.mock.calls;
       expect(n_submit).toEqual(1);
-      expect(n_submit_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_submit_timestamp).toBeLessThanOrEqual(after);
     });
 
     test("don't increment n_submit if key is not Enter", () => {
@@ -164,34 +156,22 @@ describe('Input', () => {
     });
 
     test('dispatch value on blur if debounce is true', () => {
-      const before = Date.now();
       fireEvent.blur(inputElement);
-      const after = Date.now();
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_blur, n_blur_timestamp, value}]] = mockSetProps.mock.calls;
+      const [[{n_blur, value}]] = mockSetProps.mock.calls;
       expect(n_blur).toEqual(1);
-      expect(n_blur_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_blur_timestamp).toBeLessThanOrEqual(after);
       expect(value).toEqual('some-input-value');
     });
 
     test('dispatch value on submit if debounce is true', () => {
-      const before = Date.now();
-      fireEvent.keyUp(inputElement, {
-        key: 'Enter',
-        code: 13,
-        charCode: 13
-      });
-      const after = Date.now();
+      fireEvent.keyUp(inputElement, {key: 'Enter', code: 13, charCode: 13});
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_submit, n_submit_timestamp, value}]] = mockSetProps.mock.calls;
+      const [[{n_submit, value}]] = mockSetProps.mock.calls;
       expect(n_submit).toEqual(1);
-      expect(n_submit_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_submit_timestamp).toBeLessThanOrEqual(after);
       expect(value).toEqual('some-input-value');
     });
   });

--- a/src/components/input/__tests__/Textarea.test.js
+++ b/src/components/input/__tests__/Textarea.test.js
@@ -119,34 +119,22 @@ describe('Textarea', () => {
       expect(call3).toEqual([{value: 'abc'}]);
     });
 
-    test('track number of blurs with "n_blur" and "n_blur_timestamp"', () => {
-      const before = Date.now();
+    test('track number of blurs with "n_blur"', () => {
       fireEvent.blur(textarea);
-      const after = Date.now();
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_blur, n_blur_timestamp}]] = mockSetProps.mock.calls;
+      const [[{n_blur}]] = mockSetProps.mock.calls;
       expect(n_blur).toEqual(1);
-      expect(n_blur_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_blur_timestamp).toBeLessThanOrEqual(after);
     });
 
-    test('tracks submit with "n_submit" and "n_submit_timestamp"', () => {
-      const before = Date.now();
-      fireEvent.keyUp(textarea, {
-        key: 'Enter',
-        code: 13,
-        charCode: 13
-      });
-      const after = Date.now();
+    test('tracks submit with "n_submit"', () => {
+      fireEvent.keyUp(textarea, {key: 'Enter', code: 13, charCode: 13});
 
       expect(mockSetProps.mock.calls).toHaveLength(1);
 
-      const [[{n_submit, n_submit_timestamp}]] = mockSetProps.mock.calls;
+      const [[{n_submit}]] = mockSetProps.mock.calls;
       expect(n_submit).toEqual(1);
-      expect(n_submit_timestamp).toBeGreaterThanOrEqual(before);
-      expect(n_submit_timestamp).toBeLessThanOrEqual(after);
     });
 
     test("don't increment n_submit if key is not Enter", () => {
@@ -184,16 +172,12 @@ describe('Textarea', () => {
       test('dispatch value on blur if debounce is true', async () => {
         const user = userEvent.setup();
         await user.type(textarea, 'some text');
-        const before = Date.now();
         fireEvent.blur(textarea);
-        const after = Date.now();
 
         expect(mockSetProps.mock.calls).toHaveLength(2);
 
-        const [{n_blur, n_blur_timestamp, value}] = mockSetProps.mock.calls[1];
+        const [{n_blur, value}] = mockSetProps.mock.calls[1];
         expect(n_blur).toEqual(1);
-        expect(n_blur_timestamp).toBeGreaterThanOrEqual(before);
-        expect(n_blur_timestamp).toBeLessThanOrEqual(after);
         expect(value).toEqual('some text');
       });
 
@@ -207,11 +191,8 @@ describe('Textarea', () => {
         // one click and one submit
         expect(mockSetProps.mock.calls).toHaveLength(2);
 
-        const [{n_submit, n_submit_timestamp, value}] =
-          mockSetProps.mock.calls[1];
+        const [{n_submit, value}] = mockSetProps.mock.calls[1];
         expect(n_submit).toEqual(1);
-        expect(n_submit_timestamp).toBeGreaterThanOrEqual(before);
-        expect(n_submit_timestamp).toBeLessThanOrEqual(after);
         expect(value).toEqual('some text\n');
       });
 

--- a/src/components/listgroup/ListGroupItem.js
+++ b/src/components/listgroup/ListGroupItem.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 import RBListGroupItem from 'react-bootstrap/ListGroupItem';
 import Link from '../../private/Link';
 import {bootstrapColors} from '../../private/BootstrapColors';
@@ -26,10 +25,7 @@ const ListGroupItem = props => {
 
   const incrementClicks = () => {
     if (!disabled && setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
   const isBootstrapColor = bootstrapColors.has(color);
@@ -45,7 +41,7 @@ const ListGroupItem = props => {
       variant={isBootstrapColor ? color : null}
       style={!isBootstrapColor ? {backgroundColor: color, ...style} : style}
       className={class_name || className}
-      {...omit(['n_clicks_timestamp'], otherProps)}
+      {...otherProps}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
@@ -140,13 +136,6 @@ ListGroupItem.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/nav/NavLink.js
+++ b/src/components/nav/NavLink.js
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
-import {omit} from 'ramda';
 import classNames from 'classnames';
 import {History} from '@plotly/dash-component-plugins';
 import Link from '../../private/Link';
@@ -43,10 +42,7 @@ const NavLink = ({
 
   const incrementClicks = () => {
     if (!disabled && setProps) {
-      setProps({
-        n_clicks: n_clicks + 1,
-        n_clicks_timestamp: Date.now()
-      });
+      setProps({n_clicks: n_clicks + 1});
     }
   };
 
@@ -61,7 +57,7 @@ const NavLink = ({
       disabled={disabled}
       preOnClick={incrementClicks}
       href={href}
-      {...omit(['n_clicks_timestamp'], otherProps)}
+      {...otherProps}
       data-dash-is-loading={
         (loading_state && loading_state.is_loading) || undefined
       }
@@ -151,13 +147,6 @@ NavLink.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/nav/NavbarToggler.js
+++ b/src/components/nav/NavbarToggler.js
@@ -20,10 +20,7 @@ const NavbarToggler = ({
     <RBNavbarToggle
       onClick={() => {
         if (setProps) {
-          setProps({
-            n_clicks: n_clicks + 1,
-            n_clicks_timestamp: Date.now()
-          });
+          setProps({n_clicks: n_clicks + 1});
         }
       }}
       className={class_name || className}
@@ -83,13 +80,6 @@ NavbarToggler.propTypes = {
    * that this element has been clicked on.
    */
   n_clicks: PropTypes.number,
-
-  /**
-   * An integer that represents the time (in ms since 1970)
-   * at which n_clicks changed. This can be used to tell
-   * which button was changed most recently.
-   */
-  n_clicks_timestamp: PropTypes.number,
 
   /**
    * Object that holds the loading state object coming from dash-renderer

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -34,11 +34,7 @@ const Toast = props => {
 
   const dismiss = () => {
     if (setProps) {
-      setProps({
-        is_open: false,
-        n_dismiss: n_dismiss + 1,
-        n_dismiss_timestamp: Date.now()
-      });
+      setProps({is_open: false, n_dismiss: n_dismiss + 1});
     }
   };
 
@@ -66,13 +62,7 @@ const Toast = props => {
         (loading_state && loading_state.is_loading) || undefined
       }
       {...omit(
-        [
-          'n_dismiss_timestamp',
-          'persistence',
-          'persisted_props',
-          'persistence_type',
-          'setProps'
-        ],
+        ['persistence', 'persisted_props', 'persistence_type', 'setProps'],
         otherProps
       )}
     >
@@ -221,15 +211,6 @@ Toast.propTypes = {
    * been clicked on.
    */
   n_dismiss: PropTypes.number,
-
-  /**
-   * Use of *_timestamp props has been deprecated in Dash in favour of dash.callback_context.
-   * See "How do I determine which Input has changed?" in the Dash FAQs https://dash.plot.ly/faqs.
-   *
-   * An integer that represents the time (in ms since 1970) at which n_dismiss
-   * changed. This can be used to tell which button was changed most recently.
-   */
-  n_dismiss_timestamp: PropTypes.number,
 
   /**
    * Add a contextually coloured icon to the header of the toast. Options are:


### PR DESCRIPTION
These props have been redundant for years, with dash callback_context being the preferred approach for determining which inputs triggered a callback.