### PR TITLE
Keep prop order

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ deploy-docs: _copy-examples
     git branch -D just-push-docs docs-deploy
 
 _build-py: && _move-generated-files _build-package
-    uv run dash-generate-components ./src/components dash_bootstrap_components -i "^_|__tests__"
+    uv run dash-generate-components ./src/components dash_bootstrap_components -i "^_|__tests__" -k ALL
     cp dash_bootstrap_components/_components/dash_bootstrap_components.min.js dist
 
 _build-package:


### PR DESCRIPTION
Add argument to dash-generate-components to preserve the prop order when building the Python library.