### PR TITLE
feat: use URL for logo in README so it displays properly on PyPI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://dash-bootstrap-components.opensource.faculty.ai/">
-    <img src="./readme-images/logo.png" alt="dash-bootstrap-components logo" width="200" height="200">
+    <img src="https://github.com/facultyai/dash-bootstrap-components/blob/main/readme-images/logo.png" alt="dash-bootstrap-components logo" width="200" height="200">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://dash-bootstrap-components.opensource.faculty.ai/">
-    <img src="https://github.com/facultyai/dash-bootstrap-components/blob/main/readme-images/logo.png" alt="dash-bootstrap-components logo" width="200" height="200">
+    <img src="https://cdn.jsdelivr.net/gh/facultyai/dash-bootstrap-components@main/readme-images/logo.png" alt="dash-bootstrap-components logo" width="200" height="200">
   </a>
 </p>
 


### PR DESCRIPTION
Original code used a relative path to the logo file in `README.md`, but that does not resolve properly when the package is uploaded to pypi.org.  This PR replaces the relative path with the full GitHub URL to the logo file, which is clunky but works.