### PR TITLE
Prerelease 2.0.0rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.1-dev"
+__version__ = "2.0.0rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "1.7.1-dev",
+  "version": "2.0.0rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "1.7.1-dev"
+    assert __version__ == "2.0.0rc1"

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "dash"
-version = "3.0.0rc3"
+version = "3.0.0rc4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
@@ -274,9 +274,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/4e/771b4716d5c555149602e85cf2d74edc65e59149aa08f0607af45ab7eda9/dash-3.0.0rc3.tar.gz", hash = "sha256:cfd8fbf541011459fa29f2334d661495c9e0ebd420912a403bb1b946e3e9ebc0", size = 7465229 }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/46/9c13b16b44e506c6cb1a6198c5359fa7b8f83dec6a6a95779477d133cc98/dash-3.0.0rc4.tar.gz", hash = "sha256:26b7105b3e37ed145cc268af3d19b1b06029bc7a7132f5b22e8f2d8c257c81c7", size = 7466167 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/a4/b4341518903d86469f008c1f024039f2197b24de6936f4eb1503e274b0f9/dash-3.0.0rc3-py3-none-any.whl", hash = "sha256:a2ad23a981184ea0a5646f9a2f14b88bb68888fe53361f7e70758b9bcde7c5ad", size = 7816418 },
+    { url = "https://files.pythonhosted.org/packages/5f/84/8335ea958c5e667c313ed961299d43dc5aa2a05b6f1aa89114ff90a7e283/dash-3.0.0rc4-py3-none-any.whl", hash = "sha256:2b284a581b62f068b2f0b5998818c16191104a4c40ab07ded41185ca92a874e5", size = 7818169 },
 ]
 
 [package.optional-dependencies]
@@ -322,7 +322,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dash", specifier = "==3.0.0rc3" },
+    { name = "dash", specifier = "==3.0.0rc4" },
     { name = "numpy", marker = "extra == 'pandas'", specifier = ">=2.0.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.3" },
 ]


### PR DESCRIPTION
This is a release candidate of dash-bootstrap-components version 2.0.0!

This version makes various internal updates for compatibility with Dash 3.0.0. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Added
- Added Label.xxl prop. The logic for this was in place but the prop was not exposed to the Component due to a missing prop-types declaration ([PR 1084](https://github.com/facultyai/dash-bootstrap-components/pull/1084))
- `Spinner` and `Placeholder` now accept the `target_components` prop which functions like `dcc.Loading` ([PR 1080](https://github.com/facultyai/dash-bootstrap-components/pull/1080))
- Added `display` prop for `Spinner` and `Placeholder` to force the component to show ([PR 1080](https://github.com/facultyai/dash-bootstrap-components/pull/1080))
- Added `disabled` prop to `CardLink` ([PR 1084](https://github.com/facultyai/dash-bootstrap-components/pull/1084))

### Changed
- Made `Modal` styling props consistent. `modal_class_name` and `modalClassName` are renamed to `class_name` and `className` respectively which target the same element as `style`. `class_name` and `className` previously set styles on the modal dialog, which should now be done with `dialog_class_name` and `dialogClassName` respectively. This is consistent with behaviour of `style` and `dialog_style` ([PR 1090](https://github.com/facultyai/dash-bootstrap-components/pull/1090))

### Removed
- Removed the following props which had no effect: Carousel.ride, DropdownMenu.addon_type, Navbar.light, NavbarSimple.light, Popover.innerClassName, Popover.inner_class_name. ([PR 1088](https://github.com/facultyai/dash-bootstrap-components/pull/1088)) ([PR 1090](https://github.com/facultyai/dash-bootstrap-components/pull/1090))
- Removed the following deprecated props: DropdownMenu.right, Table.dark ([PR 1084](https://github.com/facultyai/dash-bootstrap-components/pull/1084))
- All `_timestamp` props. Use callback context instead. ([PR 1082](https://github.com/facultyai/dash-bootstrap-components/pull/1082))
