### PR TITLE
Prerelease 2.0.1-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.1-dev"
+__version__ = "2.0.1-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "2.0.1-dev",
+  "version": "2.0.1-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.1-dev"
+    assert __version__ == "2.0.1-rc1"


### PR DESCRIPTION
This is a pre-release for dash-bootstrap-components version 2.0.1! This version fixes bugs and updates CDN links. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Changed
- Updated CDN links for Bootstrap CSS, Bootswatch CSS, Bootstrap Icons and FontAwesome Icons ([PR 1109](https://github.com/facultyai/dash-bootstrap-components/pull/1109))
- Dropped upper bound on supported Python versions ([PR 1107](https://github.com/facultyai/dash-bootstrap-components/pull/1107))

### Fixed
- Fixed regression preventing `dbc.Button` from being used in conjunction with `dcc.ConfirmDialogProvider` ([PR 1111](https://github.com/facultyai/dash-bootstrap-components/pull/1111))