### PR TITLE
#1119 Make sure tab updates are rendered correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 maintainers = [{ name = "Tom Begley", email = "tomcbegley@gmail.com" }]
 requires-python = ">=3.9"
 dependencies = [
-    "dash>=3.0.0",
+    "dash>=3.0.3",
 ]
 classifiers = [
     "Framework :: Dash",

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -147,6 +147,10 @@ Tabs.dashPersistence = {
   persistence_type: 'local'
 };
 
+// Make sure that updates to the Tabs children are properly rendered
+// See https://github.com/facultyai/dash-bootstrap-components/issues/1119
+Tabs.dashChildrenUpdate = true;
+
 Tabs.propTypes = {
   /**
    * The children of this Tabs component. Each child should be a Tab component.

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "dash"
-version = "3.0.0"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
@@ -271,13 +271,12 @@ dependencies = [
     { name = "requests" },
     { name = "retrying" },
     { name = "setuptools" },
-    { name = "stringcase" },
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/9c/2a9f90b55fd9a5e27b89f20c8b52e05db52c49bb99213c0323b9116dbe9f/dash-3.0.0.tar.gz", hash = "sha256:2cbb071836b3ca546dbe38655083908b8be543f3bea9c4bf660b96490d3d4953", size = 7608640 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/f6/c337e0f019a6faaeb2cf42ae846f4736136e62de5522b02ae1acad1bb26f/dash-3.0.3.tar.gz", hash = "sha256:86d3038ae9f09e1f246937afbab5451c9db5a3832911c325d2e1f0bcefe2b7c9", size = 7603520 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/b1/4538ba05deedd430167bbee3ee1589276994e4a85c9e4d52f467080ecc33/dash-3.0.0-py3-none-any.whl", hash = "sha256:684de3765bdb24f2c5a7b5d9d4dffb02bb122586b08784a394769004af444f03", size = 7951998 },
+    { url = "https://files.pythonhosted.org/packages/e8/62/4f7ed64d193fe8a3d13abe03694bd752ca3c34fce8b025af794585f3cc2a/dash-3.0.3-py3-none-any.whl", hash = "sha256:9c6577e056971590c002c07fd26376d3d501bddb39804466e401876fb1e043ac", size = 7952319 },
 ]
 
 [package.optional-dependencies]
@@ -323,7 +322,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dash", specifier = ">=3.0.0" },
+    { name = "dash", specifier = ">=3.0.3" },
     { name = "numpy", marker = "extra == 'pandas'", specifier = ">=2.0.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.3" },
 ]
@@ -1092,12 +1091,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9", size = 36186 },
 ]
-
-[[package]]
-name = "stringcase"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008", size = 2958 }
 
 [[package]]
 name = "tenacity"


### PR DESCRIPTION
# Summary

This PR sets `dashChildrenUpdate` to `true` on the tabs component as advised by https://github.com/plotly/dash/pull/3268 to address a regression introduced in Dash 3 that would prevent tabs from getting rendered properly after updating them via a callback.

# References

- Fixes https://github.com/facultyai/dash-bootstrap-components/issues/1119