### PR TITLE
Prerelease 2.0.2-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.2-dev"
+__version__ = "2.0.2-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "2.0.2-dev",
+  "version": "2.0.2-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.2-dev"
+    assert __version__ == "2.0.2-rc1"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -326,7 +325,6 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'pandas'", specifier = ">=2.0.2" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2.3" },
 ]
-provides-extras = ["pandas"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This is a pre-release for dash-bootstrap-components version 2.0.2! This version fixes a bug in the Tabs component and updates the version requirement for the _dash_ package. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Changed
- _dash-bootstrap-components_ now requires dash>=3.0.3 ([PR 1120](https://github.com/facultyai/dash-bootstrap-components/pull/1120))

### Fixed
- Updating a `Tab` in a callback now triggers a rerender of the parent `Tabs` component ([PR 1120](https://github.com/facultyai/dash-bootstrap-components/pull/1120))

Thanks @FRosner for the contribution!