### PR TITLE
Fix: Dead link and deprecation warnings

### DIFF
--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -1,6 +1,6 @@
 # How to release dash-bootstrap-components
 
-This is a set of instructions for releasing _dash-bootstrap-components_. The release process is somewhat automated with an [`invoke`](http://docs.pyinvoke.org/en/latest/getting_started.html>) task file. You will need `invoke` and `semver` installed.
+This is a set of instructions for releasing _dash-bootstrap-components_. The release process is somewhat automated with an [`invoke`](https://docs.pyinvoke.org/en/latest/getting-started.html) task file. You will need `invoke` and `semver` installed.
 
 - Run `invoke prerelease <version>`, where `version` is the version number of the release candidate. If you are aiming to release version `0.0.7`, this will be `0.0.7-rc1`. This will automatically bump the version numbers and push a release branch to GitHub.
 

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -1,18 +1,18 @@
 # How to release dash-bootstrap-components
 
-This is a set of instructions for releasing _dash-bootstrap-components_. The release process is somewhat automated with an [`invoke`](https://docs.pyinvoke.org/en/latest/getting-started.html) task file. You will need `invoke` and `semver` installed.
+This is a set of instructions for releasing _dash-bootstrap-components_. The release process is somewhat automated with [`just`](https://github.com/casey/just)
 
-- Run `invoke prerelease <version>`, where `version` is the version number of the release candidate. If you are aiming to release version `0.0.7`, this will be `0.0.7-rc1`. This will automatically bump the version numbers and push a release branch to GitHub.
+- Run `just prerelease <version>`, where `version` is the version number of the release candidate. If you are aiming to release version `0.0.7`, this will be `0.0.7-rc1`. This will automatically bump the version numbers and push a release branch to GitHub.
 
 - Create a pull request with this branch, and document changes in the release in the comment of your pull request. The title and comment of the pull request are used by GitHub Actions to make the release on GitHub. See the other releases or the [changelog](https://dash-bootstrap-components.opensource.faculty.ai/changelog/) for previous release summaries.
 
 - Merge the pull request. This will trigger a GitHub Action that will build the package and upload to PyPI.
 
-- Verify that you can install the new version and that it works correctly with `pip install dash-bootstrap-components==<new version>`. It's best to verify the installation on a clean virtual machine (rather than just in a new environment) since installation is more complex than for pure Python packages.
+- Verify that you can install the new version and that it works correctly with `pip install dash-bootstrap-components==<new version>`.
 
 - If the manual installation tests failed, fix the issue and repeat the previous steps with `rc2` etc. If installing worked, proceed to the next steps.
 
-- Run `invoke release <version>`, where `version` is the version number of the release (e.g. `0.7.0`). This will push a release branch to GitHub.
+- Run `just release <version>`, where `version` is the version number of the release (e.g. `0.0.7`). This will push a release branch to GitHub.
 
 - As before, open a pull request and use the title and comment to document changes to the package. When the pull request is merged GitHub Actions will build the packages and upload it to PyPI.
 
@@ -23,5 +23,5 @@ This is a set of instructions for releasing _dash-bootstrap-components_. The rel
 The documentation is currently hosted on Heroku. To push documentation updates:
 
 ```sh
-invoke documentation
+just deploy-docs
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,7 @@ authors = [
 ]
 maintainers = [{ name = "Tom Begley", email = "tomcbegley@gmail.com" }]
 requires-python = ">=3.9"
-dependencies = [
-    "dash>=3.0.3",
-]
+dependencies = ["dash>=3.0.3"]
 classifiers = [
     "Framework :: Dash",
     "License :: OSI Approved :: Apache Software License",

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -112,14 +112,14 @@ Breadcrumb.propTypes = {
   key: PropTypes.string,
 
   /**
-   * **DEPRECATED** - Use class_name instead.
+   * **DEPRECATED** Use `class_name` instead.
    *
    * Additional CSS classes to apply to the Breadcrumb.
    */
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** - use item_class_name instead.
+   * **DEPRECATED** Use `item_class_name` instead.
    *
    * Additional CSS classes to apply to each item.
    */

--- a/src/components/carousel/Carousel.js
+++ b/src/components/carousel/Carousel.js
@@ -231,7 +231,8 @@ Carousel.propTypes = {
   /**
    * **DEPRECATED** Use `class_name` instead.
    *
-   * efines the className of the carousel container. Additional CSS classes to apply to the Carousel.
+   * Defines the className of the carousel container. Additional CSS classes 
+   * to apply to the Carousel.
    */
   className: PropTypes.string,
 

--- a/src/components/carousel/Carousel.js
+++ b/src/components/carousel/Carousel.js
@@ -231,7 +231,7 @@ Carousel.propTypes = {
   /**
    * **DEPRECATED** Use `class_name` instead.
    *
-   * Defines the className of the carousel container. Additional CSS classes 
+   * Defines the className of the carousel container. Additional CSS classes
    * to apply to the Carousel.
    */
   className: PropTypes.string,

--- a/src/components/dropdownmenu/DropdownMenu.js
+++ b/src/components/dropdownmenu/DropdownMenu.js
@@ -206,7 +206,7 @@ DropdownMenu.propTypes = {
   /**
    * **DEPRECATED** Use `toggle_class_name` instead.
    *
-   * Additional CSS classes to apply to the DropdownMenu The classes
+   * Additional CSS classes to apply to the DropdownMenu. The classes
    * specified with this prop will be applied to the DropdownMenu toggle.
    */
   toggleClassName: PropTypes.string,

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -373,49 +373,49 @@ Textarea.propTypes = {
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `accesskey` instead
+   * **DEPRECATED** Use `accesskey` instead.
    *
    * Defines a keyboard shortcut to activate or add focus to the element.
    */
   accessKey: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `autofocus` instead
+   * **DEPRECATED** Use `autofocus` instead.
    *
    * The element should be automatically focused after the page loaded.
    */
   autoFocus: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `contenteditable` instead
+   * **DEPRECATED** Use `contenteditable` instead.
    *
    * Indicates whether the element's content is editable.
    */
   contentEditable: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   * **DEPRECATED** Use `contextmenu` instead
+   * **DEPRECATED** Use `contextmenu` instead.
    *
    * Defines the ID of a <menu> element which will serve as the element's context menu.
    */
   contextMenu: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `maxlength` instead
+   * **DEPRECATED** Use `maxlength` instead.
    *
    * Defines the maximum number of characters allowed in the element.
    */
   maxLength: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   * **DEPRECATED** Use `minlength` instead
+   * **DEPRECATED** Use `minlength` instead.
    *
    * Defines the minimum number of characters allowed in the element.
    */
   minLength: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   * **DEPRECATED** Use `readonly` instead
+   * **DEPRECATED** Use `readonly` instead.
    *
    * Indicates whether the element can be edited.
    */
@@ -425,7 +425,7 @@ Textarea.propTypes = {
   ]),
 
   /**
-   * **DEPRECATED** Use `spellcheck` instead
+   * **DEPRECATED** Use `spellcheck` instead.
    *
    * Indicates whether spell checking is allowed for the element.
    */
@@ -436,7 +436,7 @@ Textarea.propTypes = {
   ]),
 
   /**
-   * **DEPRECATED** Use `tabindex` instead
+   * **DEPRECATED** Use `tabindex` instead.
    *
    * Overrides the browser's default tab order and follows the one specified instead.
    */

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -218,7 +218,7 @@ Modal.propTypes = {
   contentStyle: PropTypes.object,
 
   /**
-   * **DEPRECATED** Use `content_style` instead.
+   * **DEPRECATED** Use `backdrop_style` instead.
    *
    * Inline CSS styles to apply to the backdrop
    */

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -206,68 +206,68 @@ Modal.propTypes = {
   /**
    * **DEPRECATED** Use `dialog_style` instead.
    *
-   * Inline CSS styles to apply to the dialog
+   * Inline CSS styles to apply to the dialog.
    */
   dialogStyle: PropTypes.object,
 
   /**
    * **DEPRECATED** Use `content_style` instead.
    *
-   * Inline CSS styles to apply to the content
+   * Inline CSS styles to apply to the content.
    */
   contentStyle: PropTypes.object,
 
   /**
    * **DEPRECATED** Use `backdrop_style` instead.
    *
-   * Inline CSS styles to apply to the backdrop
+   * Inline CSS styles to apply to the backdrop.
    */
   backdropStyle: PropTypes.object,
 
   /**
    * **DEPRECATED** Use `class_name` instead.
    *
-   * Additional CSS classes to apply to the Modal
+   * Additional CSS classes to apply to the Modal.
    */
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `backdrop_class_name` instead
+   * **DEPRECATED** Use `backdrop_class_name` instead.
    *
    * Additional CSS classes to apply to the modal-backdrop.
    */
   backdropClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `content_class_name` instead
+   * **DEPRECATED** Use `content_class_name` instead.
    *
    * Additional CSS classes to apply to the modal-content.
    */
   contentClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `dialog_class_name` instead
+   * **DEPRECATED** Use `dialog_class_name` instead.
    *
    * Additional CSS classes to apply to the modal-dialog.
    */
   dialogClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `autofocus` instead
+   * **DEPRECATED** Use `autofocus` instead.
    *
    * 	Puts the focus on the modal when initialized.
    */
   autoFocus: PropTypes.bool,
 
   /**
-   * **DEPRECATED** Use `labelledby` instead
+   * **DEPRECATED** Use `labelledby` instead.
    *
    * The ARIA labelledby attribute
    */
   labelledBy: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `zindex` instead
+   * **DEPRECATED** Use `zindex` instead.
    *
    * Set the z-index of the modal. Default 1050.
    */

--- a/src/components/offcanvas/Offcanvas.js
+++ b/src/components/offcanvas/Offcanvas.js
@@ -136,28 +136,28 @@ Offcanvas.propTypes = {
   labelledby: PropTypes.string,
 
   /**
-   * **DEPRECATED** - Use class_name instead.
+   * **DEPRECATED** Use `class_name` instead.
    *
    * Additional CSS classes to apply to the Offcanvas
    */
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** - Use backdrop_class_name instead.
+   * **DEPRECATED** Use `backdrop_class_name` instead.
    *
    * CSS class to apply to the backdrop.
    */
   backdropClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `autofocus` instead
+   * **DEPRECATED** Use `autofocus` instead.
    *
    * 	Puts the focus on the modal when initialized.
    */
   autoFocus: PropTypes.bool,
 
   /**
-   * **DEPRECATED** Use `labelledby` instead
+   * **DEPRECATED** Use `labelledby` instead.
    *
    * The ARIA labelledby attribute
    */

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -210,7 +210,7 @@ Pagination.propTypes = {
   class_name: PropTypes.string,
 
   /**
-   * **DEPRECATED** - Use class_name instead.
+   * **DEPRECATED** Use `class_name` instead.
    *
    * Additional CSS classes to apply to the Pagination.
    */

--- a/src/components/spinner/Spinner.js
+++ b/src/components/spinner/Spinner.js
@@ -259,14 +259,14 @@ Spinner.propTypes = {
   ),
 
   /**
-   * **DEPRECATED** - use `fullscreen_class_name` instead.
+   * **DEPRECATED** Use `fullscreen_class_name` instead.
    *
    * Additional CSS classes to apply to the Spinner when fullscreen=True.
    */
   fullscreenClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** - use `spinner_class_name` instead.
+   * **DEPRECATED** Use `spinner_class_name` instead.
    *
    * CSS class names to apply to the spinner.
    */

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -115,7 +115,7 @@ Tab.propTypes = {
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `tab_class_name` instead
+   * **DEPRECATED** Use `tab_class_name` instead.
    *
    * Additional CSS classes to apply to the Tabs. The classes
    * specified with this prop will be applied to the NavItem in the tab.
@@ -123,7 +123,7 @@ Tab.propTypes = {
   tabClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `active_tab_class_name` instead
+   * **DEPRECATED** Use `active_tab_class_name` instead.
    *
    * Additional CSS classes to apply to the Tabs. The classes
    * specified with this prop will be applied to the NavItem in the tab when it
@@ -132,7 +132,7 @@ Tab.propTypes = {
   activeTabClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `label_class_name` instead
+   * **DEPRECATED** Use `label_class_name` instead.
    *
    * Additional CSS classes to apply to the Tabs. The classes
    * specified with this prop will be applied to the NavLink in the tab.
@@ -140,7 +140,7 @@ Tab.propTypes = {
   labelClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** Use `active_label_class_name` instead
+   * **DEPRECATED** Use `active_label_class_name` instead.
    *
    * Additional CSS classes to apply to the Tabs. The classes
    * specified with this prop will be applied to the NavLink in the tab when

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -228,7 +228,7 @@ Toast.propTypes = {
   className: PropTypes.string,
 
   /**
-   * **DEPRECATED** - use `header_class_name` instead
+   * **DEPRECATED** Use `header_class_name` instead.
    *
    * Additional CSS classes to apply to the Toast. The classes
    * specified with this prop will be applied to the header of the toast.
@@ -236,7 +236,7 @@ Toast.propTypes = {
   headerClassName: PropTypes.string,
 
   /**
-   * **DEPRECATED** - use `body_class_name` instead.
+   * **DEPRECATED** Use `body_class_name` instead.
    *
    * Additional CSS classes to apply to the Toast. The classes
    * specified with this prop will be applied to the body of the toast.


### PR DESCRIPTION
# Summary

This PR addresses the following minor improvements:

- Fixes a dead link to "Invoke – Getting Started" in `how-to-contribute.md`
- Fixes a deprecation warning where `Modal.backdropStyle` incorrectly referenced to `Modal.content_style` instead of the correct `Modal.backdrop_style`
- Uniform deprecation warning messages to ensure consistent formatting