### PR TITLE
Prerelease 2.0.3-rc2

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.3-dev"
+__version__ = "2.0.3-rc2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "2.0.3-dev",
+  "version": "2.0.3-rc2",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:facultyai/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.3-dev"
+    assert __version__ == "2.0.3-rc2"


### PR DESCRIPTION
This is a release candidate for dash-bootstrap-components version 2.0.3! This version fixes a bug in the Tabs component and updates the version requirement for the _dash_ package. We have also updated CDN links for Bootstrap stylesheets. Please continue to report problems on our [issue tracker](https://github.com/facultyai/dash-bootstrap-components/issues).

### Changed
- _dash-bootstrap-components_ now requires dash>=3.0.4 ([PR 1129](https://github.com/facultyai/dash-bootstrap-components/pull/1129))
- Update the version of Bootstrap CDN links to 5.3.6 ([PR 1130](https://github.com/facultyai/dash-bootstrap-components/pull/1130))
- Update docs domain to dash-bootstrap-components.com ([PR 1133](https://github.com/facultyai/dash-bootstrap-components/pull/1133))

### Fixed
- Fixed bug that caused an error message when changing the number of children in `Tabs` component ([PR 1128](https://github.com/facultyai/dash-bootstrap-components/pull/1128))