### PR TITLE
Prerelease 2.0.5-rc4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "2.0.5-rc3",
+  "version": "2.0.5-rc4",
   "description": "Bootstrap components for Plotly Dash",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dash-bootstrap-components"
-version = "2.0.5rc3"
+version = "2.0.5rc4"
 description = "Bootstrap themed components for use in Plotly Dash"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.5rc3"
+    assert __version__ == "2.0.5rc4"

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ testing = [
 
 [[package]]
 name = "dash-bootstrap-components"
-version = "2.0.5rc3"
+version = "2.0.5rc4"
 source = { editable = "." }
 dependencies = [
     { name = "dash" },


### PR DESCRIPTION
This is a pre-release candidate for version 2.0.5 of _dash-bootstrap-components_! This is a patch release updating our build process.

### Changed

- Adopt `uv-build` for building the package ([PR 1153](https://github.com/facultyai/dash-bootstrap-components/pull/1153)) 
